### PR TITLE
test: add routing tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,25 @@ import Messages from "./pages/Messages";
 
 const queryClient = new QueryClient();
 
+export const AppRoutes = () => (
+  <Routes>
+    <Route path="/" element={<Index />} />
+    <Route path="/marketplace" element={<Marketplace />} />
+    <Route path="/freelancer-hub" element={<FreelancerHub />} />
+    <Route path="/resources" element={<Resources />} />
+    <Route path="/signin" element={<SignIn />} />
+    <Route path="/get-started" element={<GetStarted />} />
+    <Route path="/profile-setup" element={<ProfileSetup />} />
+    <Route path="/profile-review" element={<ProfileReview />} />
+    <Route path="/subscription-plans" element={<SubscriptionPlans />} />
+    <Route path="/partnership-hub" element={<PartnershipHub />} />
+    <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+    <Route path="/terms-of-service" element={<TermsOfService />} />
+    <Route path="/messages" element={<Messages />} />
+    <Route path="*" element={<NotFound />} />
+  </Routes>
+);
+
 const App = () => (
   <ThemeProvider defaultTheme="light">
     <QueryClientProvider client={queryClient}>
@@ -30,22 +49,7 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/marketplace" element={<Marketplace />} />
-              <Route path="/freelancer-hub" element={<FreelancerHub />} />
-              <Route path="/resources" element={<Resources />} />
-              <Route path="/signin" element={<SignIn />} />
-              <Route path="/get-started" element={<GetStarted />} />
-              <Route path="/profile-setup" element={<ProfileSetup />} />
-              <Route path="/profile-review" element={<ProfileReview />} />
-              <Route path="/subscription-plans" element={<SubscriptionPlans />} />
-              <Route path="/partnership-hub" element={<PartnershipHub />} />
-              <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-              <Route path="/terms-of-service" element={<TermsOfService />} />
-              <Route path="/messages" element={<Messages />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <AppRoutes />
           </BrowserRouter>
         </AppProvider>
       </TooltipProvider>

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+
+import { AppRoutes } from '../App';
+
+vi.mock('../pages/Index', () => ({ default: () => <div>Home Page</div> }));
+vi.mock('../pages/Marketplace', () => ({ default: () => <div>Marketplace Page</div> }));
+vi.mock('../pages/Resources', () => ({ default: () => <div>Resources Page</div> }));
+vi.mock('../pages/NotFound', () => ({ default: () => <div>Not Found</div> }));
+vi.mock('../pages/SignIn', () => ({ SignIn: () => <div>Sign In Page</div> }));
+vi.mock('../pages/GetStarted', () => ({ GetStarted: () => <div>Get Started Page</div> }));
+vi.mock('../pages/SubscriptionPlans', () => ({ SubscriptionPlans: () => <div>Subscription Plans Page</div> }));
+vi.mock('../pages/PartnershipHub', () => ({ PartnershipHub: () => <div>Partnership Hub Page</div> }));
+vi.mock('../pages/ProfileSetup', () => ({ ProfileSetup: () => <div>Profile Setup Page</div> }));
+vi.mock('../components/ProfileReview', () => ({ ProfileReview: () => <div>Profile Review Page</div> }));
+vi.mock('../pages/FreelancerHub', () => ({ default: () => <div>Freelancer Hub Page</div> }));
+vi.mock('../pages/PrivacyPolicy', () => ({ default: () => <div>Privacy Policy Page</div> }));
+vi.mock('../pages/TermsOfService', () => ({ default: () => <div>Terms Of Service Page</div> }));
+vi.mock('../pages/Messages', () => ({ default: () => <div>Messages Page</div> }));
+
+const routes = [
+  { path: '/', text: 'Home Page' },
+  { path: '/marketplace', text: 'Marketplace Page' },
+  { path: '/freelancer-hub', text: 'Freelancer Hub Page' },
+  { path: '/resources', text: 'Resources Page' },
+  { path: '/signin', text: 'Sign In Page' },
+  { path: '/get-started', text: 'Get Started Page' },
+  { path: '/profile-setup', text: 'Profile Setup Page' },
+  { path: '/profile-review', text: 'Profile Review Page' },
+  { path: '/subscription-plans', text: 'Subscription Plans Page' },
+  { path: '/partnership-hub', text: 'Partnership Hub Page' },
+  { path: '/privacy-policy', text: 'Privacy Policy Page' },
+  { path: '/terms-of-service', text: 'Terms Of Service Page' },
+  { path: '/messages', text: 'Messages Page' },
+];
+
+describe('AppRoutes', () => {
+  it.each(routes)('renders %s', ({ path, text }) => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
+
+  it('renders NotFound for unknown paths', () => {
+    render(
+      <MemoryRouter initialEntries={['/unknown']}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Not Found')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- extract `AppRoutes` for easier testing and export it
- add comprehensive routing tests using `MemoryRouter` and mocked pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7cb85b9408328b001de4a9ef89918