### PR TITLE
test: add NotificationCenter tests

### DIFF
--- a/src/components/__tests__/NotificationCenter.test.tsx
+++ b/src/components/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect } from 'vitest';
+import { NotificationCenter } from '../NotificationCenter';
+
+// Mock AppContext to provide a user
+vi.mock('../../contexts/AppContext', () => ({
+  useAppContext: () => ({ user: { id: 'user1', email: 'test@example.com' } })
+}));
+
+const fakeNotifications = [
+  {
+    id: '1',
+    type: 'test',
+    title: 'Test Notification',
+    message: 'Hello World',
+    data: null,
+    read: false,
+    created_at: new Date().toISOString()
+  },
+  {
+    id: '2',
+    type: 'test',
+    title: 'Another Notification',
+    message: 'Hi again',
+    data: null,
+    read: true,
+    created_at: new Date().toISOString()
+  }
+];
+
+const updateEqMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+// Mock Supabase client
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: fakeNotifications, error: null }),
+      update: vi.fn().mockReturnValue({ eq: updateEqMock })
+    })),
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() })
+    }))
+  }
+}));
+
+describe('NotificationCenter', () => {
+  it('displays initial unread count and updates after marking as read', async () => {
+    render(<NotificationCenter />);
+
+    // wait for notifications to load and unread badge to show
+    const badge = await screen.findByText('1');
+    expect(badge).toBeInTheDocument();
+
+    // open notification sheet
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+
+    // find mark-as-read button inside first notification card
+    const title = await screen.findByText('Test Notification');
+    const card = title.closest('div');
+    const markButton = within(card as HTMLElement).getByRole('button');
+    fireEvent.click(markButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for NotificationCenter verifying unread count badge and mark-as-read state updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run --environment jsdom` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cb8aaf948328ad7bf70ce7d1cc63