### PR TITLE
test: add MessageCenter component tests

### DIFF
--- a/src/components/messaging/__tests__/MessageCenter.test.tsx
+++ b/src/components/messaging/__tests__/MessageCenter.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { MessageCenter } from '../MessageCenter';
+
+vi.mock('@/lib/supabase', () => {
+  return {
+    supabase: {
+      auth: {
+        getUser: vi.fn(),
+      },
+      functions: {
+        invoke: vi.fn(),
+      },
+    },
+  };
+});
+
+import { supabase } from '@/lib/supabase';
+
+describe('MessageCenter', () => {
+  const mockMessages = [
+    {
+      id: '1',
+      subject: 'Hello',
+      content: 'Hi there',
+      read: false,
+      created_at: '2024-01-01T00:00:00Z',
+      sender: { id: 's1', full_name: 'Alice' },
+      recipient: { id: 'u1', full_name: 'Bob' },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (supabase.auth.getUser as any).mockResolvedValue({ data: { user: { id: 'u1' } } });
+    (supabase.functions.invoke as any)
+      .mockResolvedValueOnce({ data: { messages: mockMessages }, error: null })
+      .mockResolvedValueOnce({ data: {}, error: null })
+      .mockResolvedValueOnce({ data: { messages: mockMessages }, error: null });
+  });
+
+  it('renders messages, sends new message, and resets form', async () => {
+    render(<MessageCenter />);
+
+    // Messages render
+    expect(await screen.findByText('Hello')).toBeInTheDocument();
+
+    // Compose message
+    fireEvent.click(screen.getByRole('button', { name: /compose/i }));
+    fireEvent.change(screen.getByPlaceholderText('Recipient ID'), { target: { value: 'u2' } });
+    fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'New Subject' } });
+    fireEvent.change(screen.getByPlaceholderText('Message content...'), { target: { value: 'New Content' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(supabase.functions.invoke).toHaveBeenCalledWith(
+        'messaging-system',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            action: 'send_message',
+            sender_id: 'u1',
+            recipient_id: 'u2',
+            subject: 'New Subject',
+            content: 'New Content',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/compose message/i)).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /compose/i }));
+    expect(screen.getByPlaceholderText('Recipient ID')).toHaveValue('');
+    expect(screen.getByPlaceholderText('Subject')).toHaveValue('');
+    expect(screen.getByPlaceholderText('Message content...')).toHaveValue('');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for MessageCenter component, mocking Supabase functions for message retrieval and sending

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cb8c5d448328a929fe2b255b7af0