### PR TITLE
Add snapshot tests for HeroSection and StatsSection

### DIFF
--- a/src/components/__tests__/HeroSection.snapshot.test.tsx
+++ b/src/components/__tests__/HeroSection.snapshot.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import HeroSection from '../HeroSection';
+
+describe('HeroSection', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<HeroSection />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/StatsSection.snapshot.test.tsx
+++ b/src/components/__tests__/StatsSection.snapshot.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StatsSection from '../StatsSection';
+
+vi.mock('@/lib/supabase', () => {
+  const from = (table: string) => {
+    if (table === 'business_stats') {
+      return {
+        select: () => ({
+          eq: () => ({
+            order: async () => ({ data: [], error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === 'freelancers') {
+      return {
+        select: () => Promise.resolve({ count: 0 }),
+      };
+    }
+    if (table === 'profiles') {
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ count: 0 }),
+        }),
+      };
+    }
+    return {
+      select: () => Promise.resolve({ data: [], error: null }),
+    };
+  };
+  return { supabase: { from } };
+});
+
+describe('StatsSection', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<StatsSection />);
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add snapshot test for HeroSection
- add snapshot test for StatsSection with mocked supabase client

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b7cb950ff08328b6f15dc66541068f