### PR TITLE
Add accessibility testing with axe

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.5",
+    "jest-axe": "^7.0.0"
   }
 }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, test, expect } from 'vitest';
+import Header from '../Header';
+
+vi.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => ({ user: null, loading: false, signOut: vi.fn() }),
+}));
+
+vi.mock('../NotificationCenter', () => ({
+  NotificationCenter: () => <div />,
+}));
+
+vi.mock('../DonateButton', () => ({
+  DonateButton: () => <button>Donate</button>,
+}));
+
+test('Header has no accessibility violations', async () => {
+  const { container } = render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/src/components/__tests__/ProfileForm.test.tsx
+++ b/src/components/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { vi, test, expect } from 'vitest';
+import { ProfileForm } from '../ProfileForm';
+
+vi.mock('@/components/ui/button', () => ({ Button: ({ children }: any) => <button>{children}</button> }));
+vi.mock('@/components/ui/input', () => ({ Input: (props: any) => <input {...props} /> }));
+vi.mock('@/components/ui/label', () => ({ Label: ({ children }: any) => <label>{children}</label> }));
+vi.mock('@/components/ui/textarea', () => ({ Textarea: (props: any) => <textarea {...props} /> }));
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: (props: any) => <div>{props.placeholder}</div>,
+}));
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/checkbox', () => ({ Checkbox: (props: any) => <input type="checkbox" {...props} /> }));
+vi.mock('@/components/ui/radio-group', () => ({
+  RadioGroup: ({ children }: any) => <div>{children}</div>,
+  RadioGroupItem: (props: any) => <input type="radio" {...props} />,
+}));
+vi.mock('@/components/CountrySelect', () => ({ CountrySelect: () => <div /> }));
+vi.mock('@/components/AddressInput', () => ({ AddressInput: () => <div /> }));
+vi.mock('@/components/QualificationsInput', () => ({ QualificationsInput: () => <div /> }));
+vi.mock('@/components/ImageUpload', () => ({ ImageUpload: () => <div /> }));
+vi.mock('lucide-react', () => ({ ArrowLeft: () => <div /> }));
+vi.mock('../../data/countries', () => ({ sectors: ['Tech'], countries: [{ name: 'Testland', phoneCode: '+1' }] }));
+
+const noop = () => {};
+
+test('ProfileForm has no accessibility violations', async () => {
+  const { container } = render(
+    <ProfileForm accountType="professional" onSubmit={noop} onPrevious={noop} loading={false} />
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+import { expect } from 'vitest';
+import { toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,8 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts",
+  },
 }));


### PR DESCRIPTION
## Summary
- add vitest-based setup with jest-axe and jest-dom
- include accessibility tests for Header and ProfileForm

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cb9970c483288adc0b991a49f6af