### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npm run typecheck
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
- add Node.js CI workflow installing deps and running lint, typecheck and tests

## Testing
- `npm run lint` (fails: Unexpected any and other lint errors)
- `npm run typecheck` (fails: Missing script)
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b7cba68a1483288428fa9ff289f504