### PR TITLE
Add ErrorBoundary and test error route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import TestError from "./pages/TestError";
 
 const queryClient = new QueryClient();
 
@@ -30,22 +32,25 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/marketplace" element={<Marketplace />} />
-              <Route path="/freelancer-hub" element={<FreelancerHub />} />
-              <Route path="/resources" element={<Resources />} />
-              <Route path="/signin" element={<SignIn />} />
-              <Route path="/get-started" element={<GetStarted />} />
-              <Route path="/profile-setup" element={<ProfileSetup />} />
-              <Route path="/profile-review" element={<ProfileReview />} />
-              <Route path="/subscription-plans" element={<SubscriptionPlans />} />
-              <Route path="/partnership-hub" element={<PartnershipHub />} />
-              <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-              <Route path="/terms-of-service" element={<TermsOfService />} />
-              <Route path="/messages" element={<Messages />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <ErrorBoundary>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/marketplace" element={<Marketplace />} />
+                <Route path="/freelancer-hub" element={<FreelancerHub />} />
+                <Route path="/resources" element={<Resources />} />
+                <Route path="/signin" element={<SignIn />} />
+                <Route path="/get-started" element={<GetStarted />} />
+                <Route path="/profile-setup" element={<ProfileSetup />} />
+                <Route path="/profile-review" element={<ProfileReview />} />
+                <Route path="/subscription-plans" element={<SubscriptionPlans />} />
+                <Route path="/partnership-hub" element={<PartnershipHub />} />
+                <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                <Route path="/terms-of-service" element={<TermsOfService />} />
+                <Route path="/messages" element={<Messages />} />
+                <Route path="/test-error" element={<TestError />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </ErrorBoundary>
           </BrowserRouter>
         </AppProvider>
       </TooltipProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/pages/TestError.tsx
+++ b/src/pages/TestError.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TestError: React.FC = () => {
+  throw new Error('Test error');
+};
+
+export default TestError;


### PR DESCRIPTION
## Summary
- add ErrorBoundary component to capture render errors
- wrap application routes with ErrorBoundary and include test error route
- provide TestError component to demonstrate boundary behavior

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7cbb274f88328b911476e82afbcdf