### PR TITLE
Add Funding Hub route and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ProfileReview } from "./components/ProfileReview";
 import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
+import FundingHub from "./pages/FundingHub";
 import Messages from "./pages/Messages";
 
 const queryClient = new QueryClient();
@@ -34,6 +35,7 @@ const App = () => (
               <Route path="/" element={<Index />} />
               <Route path="/marketplace" element={<Marketplace />} />
               <Route path="/freelancer-hub" element={<FreelancerHub />} />
+              <Route path="/funding-hub" element={<FundingHub />} />
               <Route path="/resources" element={<Resources />} />
               <Route path="/signin" element={<SignIn />} />
               <Route path="/get-started" element={<GetStarted />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,6 +38,7 @@ const Footer = () => {
             <ul className="space-y-2">
               <li><Link to="/marketplace" className="text-gray-300 hover:text-white transition-colors">Marketplace</Link></li>
               <li><Link to="/freelancer-hub" className="text-gray-300 hover:text-white transition-colors">Freelancer Hub</Link></li>
+              <li><Link to="/funding-hub" className="text-gray-300 hover:text-white transition-colors">Funding Hub</Link></li>
               <li><Link to="/partnership-hub" className="text-gray-300 hover:text-white transition-colors">Partnership Hub</Link></li>
               <li><Link to="/resources" className="text-gray-300 hover:text-white transition-colors">Resources</Link></li>
             </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,7 @@ const Header = () => {
     { name: 'Home', href: '/' },
     { name: 'Marketplace', href: '/marketplace' },
     { name: 'Freelancer Hub', href: '/freelancer-hub' },
+    { name: 'Funding Hub', href: '/funding-hub' },
     { name: 'Resources', href: '/resources' },
     { name: 'Partnership Hub', href: '/partnership-hub' }
   ];


### PR DESCRIPTION
## Summary
- expose Funding Hub page via new `/funding-hub` route
- add Funding Hub links to site header and footer navigation

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7ccb7176c8328887c7626c2ce4b93