### PR TITLE
feat: lazy-load images

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,9 +8,11 @@ const Footer = () => {
         <div className="grid md:grid-cols-4 gap-8">
           <div className="space-y-4">
             <Link to="/" className="inline-block cursor-pointer group">
-              <img 
-                src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png" 
-                alt="WATHACI CONNECT" 
+              <img
+                src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+                alt="WATHACI CONNECT"
+                loading="lazy"
+                decoding="async"
                 className="h-18 w-auto brightness-0 invert drop-shadow-lg group-hover:scale-105 transition-transform duration-200"
               />
             </Link>

--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -131,9 +131,11 @@ export const FreelancerDirectory = () => {
         {filteredFreelancers.map((freelancer) => (
           <Card key={freelancer.id} className="hover:shadow-lg transition-shadow">
             <CardHeader className="text-center">
-              <img 
-                src={freelancer.profile_image_url || '/placeholder.svg'} 
+              <img
+                src={freelancer.profile_image_url || '/placeholder.svg'}
                 alt={freelancer.name}
+                loading="lazy"
+                decoding="async"
                 className="w-20 h-20 rounded-full mx-auto mb-4 object-cover"
               />
               <CardTitle className="text-xl">{freelancer.name}</CardTitle>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,9 +37,11 @@ const Header = () => {
       <div className="max-w-6xl mx-auto px-6">
         <div className="flex justify-between items-center py-4">
           <Link to="/" className="flex items-center space-x-3 cursor-pointer group">
-            <img 
-              src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png" 
-              alt="WATHACI CONNECT" 
+            <img
+              src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+              alt="WATHACI CONNECT"
+              loading="lazy"
+              decoding="async"
               className="h-24 w-auto drop-shadow-lg group-hover:scale-105 transition-transform duration-200"
             />
           </Link>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,9 +8,11 @@ const HeroSection = () => {
       <div className="max-w-6xl mx-auto px-6">
         <div className="text-center mb-16">
           <div className="mb-8">
-            <img 
-              src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png" 
-              alt="WATHACI CONNECT" 
+            <img
+              src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+              alt="WATHACI CONNECT"
+              loading="lazy"
+              decoding="async"
               className="h-32 w-auto mx-auto drop-shadow-2xl"
             />
           </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -28,9 +28,11 @@ export const ServiceCard = ({
     <Card className={`${color} hover:shadow-lg transition-all transform hover:-translate-y-1`}>
       <CardHeader>
         <div className="w-full h-48 mb-4 rounded-lg overflow-hidden">
-          <img 
-            src={image} 
+          <img
+            src={image}
             alt={title}
+            loading="lazy"
+            decoding="async"
             className="w-full h-full object-cover"
           />
         </div>

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -81,9 +81,11 @@ const TestimonialsSection = () => {
                     "{testimonial.testimonial_text}"
                   </p>
                   <div className="flex items-center space-x-3">
-                    <img 
-                      src={testimonial.client_image_url || '/placeholder.svg'} 
+                    <img
+                      src={testimonial.client_image_url || '/placeholder.svg'}
                       alt={testimonial.client_name}
+                      loading="lazy"
+                      decoding="async"
                       className="w-12 h-12 rounded-full object-cover"
                     />
                     <div>

--- a/src/components/marketplace/AIRecommendations.tsx
+++ b/src/components/marketplace/AIRecommendations.tsx
@@ -135,9 +135,11 @@ const AIRecommendations = ({
           {recommendations.map(rec => (
             <Card key={rec.id} className="hover:shadow-lg transition-shadow">
               <CardHeader className="p-0">
-                <img 
-                  src={rec.image} 
+                <img
+                  src={rec.image}
                   alt={rec.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-full h-32 object-cover rounded-t-lg"
                 />
               </CardHeader>

--- a/src/components/marketplace/IntegratedMarketplace.tsx
+++ b/src/components/marketplace/IntegratedMarketplace.tsx
@@ -117,9 +117,11 @@ export const IntegratedMarketplace = () => {
           <CardContent>
             <div className="grid md:grid-cols-2 gap-6">
               <div>
-                <img 
-                  src={selectedService.image} 
+                <img
+                  src={selectedService.image}
                   alt={selectedService.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-full h-64 object-cover rounded-lg mb-4"
                 />
                 <div className="space-y-4">

--- a/src/components/marketplace/ProductCard.tsx
+++ b/src/components/marketplace/ProductCard.tsx
@@ -33,9 +33,11 @@ const ProductCard = ({ product, onAddToCart, onViewDetails }: ProductCardProps) 
     <Card className="hover:shadow-lg transition-all duration-300 group">
       <CardHeader className="p-0">
         <div className="relative overflow-hidden rounded-t-lg">
-          <img 
-            src={product.image} 
+          <img
+            src={product.image}
             alt={product.name}
+            loading="lazy"
+            decoding="async"
             className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
           />
           <Button

--- a/src/components/marketplace/ServiceProviderCard.tsx
+++ b/src/components/marketplace/ServiceProviderCard.tsx
@@ -67,9 +67,11 @@ export const ServiceProviderCard = ({ service, onSelect }: ServiceProviderCardPr
     <Card className="hover:shadow-lg transition-all duration-200 group cursor-pointer" onClick={() => onSelect(service)}>
       <CardHeader className="p-0">
         <div className="relative">
-          <img 
-            src={service.image} 
+          <img
+            src={service.image}
             alt={service.title}
+            loading="lazy"
+            decoding="async"
             className="w-full h-48 object-cover rounded-t-lg group-hover:scale-105 transition-transform duration-200"
           />
           <div className="absolute top-3 left-3">

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -36,9 +36,11 @@ const SignIn = () => {
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-green-50 flex items-center justify-center p-6">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <img 
-            src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png" 
-            alt="WATHACI CONNECT" 
+          <img
+            src="https://d64gsuwffb70l.cloudfront.net/686a39ec793daf0c658a746a_1753699300137_a4fb9790.png"
+            alt="WATHACI CONNECT"
+            loading="lazy"
+            decoding="async"
             className="h-20 w-auto mx-auto mb-6 drop-shadow-lg"
           />
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Welcome Back</h1>


### PR DESCRIPTION
## Summary
- lazy-load and async decode images across UI components

## Testing
- `npm run build`
- `npx lighthouse http://localhost:4173` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lighthouse)*
- `npm run lint`
- `npm test`
- `npm run test:accessibility` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7db8e7ad4832898e13eb02c063b68