### PR TITLE
Add basic Express backend and connect via fetch

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+const services = [
+  { id: 1, name: 'Web Design' },
+  { id: 2, name: 'Accounting' }
+];
+
+const users = [
+  { id: 1, name: 'Jane' },
+  { id: 2, name: 'John' }
+];
+
+app.get('/api/services', (req, res) => {
+  res.json(services);
+});
+
+app.get('/api/users', (req, res) => {
+  res.json(users);
+});
+
+app.listen(port, () => {
+  console.log(`Backend listening on port ${port}`);
+});

--- a/index.html
+++ b/index.html
@@ -23,5 +23,13 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      fetch('/api/services')
+        .then((res) => res.json())
+        .then((data) => console.log('Services:', data));
+      fetch('/api/users')
+        .then((res) => res.json())
+        .then((data) => console.log('Users:', data));
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple Express server with `/api/services` and `/api/users` routes
- call new backend APIs from the existing front-end using `fetch`

## Testing
- `npm test` (no tests)


------
https://chatgpt.com/codex/tasks/task_e_68b7b08288c88328b501e3d44645e11e