### PR TITLE
Add CORS middleware and centralized error handling

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,12 @@
 const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const errorHandler = require('./middleware/errorHandler');
+
 const app = express();
 
+app.use(cors());
+app.use(helmet());
 app.use(express.json());
 
 const userRoutes = require('./routes/users');
@@ -8,6 +14,16 @@ app.use('/users', userRoutes);
 
 const authRoutes = require('./routes/auth');
 app.use('/auth', authRoutes);
+
+app.use(errorHandler);
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled Rejection:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception:', err);
+});
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+const errorHandler = (err, req, res, next) => {
+  console.error(err.stack || err);
+  res.status(err.status || 500).json({ error: err.message || 'Internal Server Error' });
+};
+
+module.exports = errorHandler;

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "joi": "^17.9.2",
-    "sanitize-html": "^2.11.0"
+    "sanitize-html": "^2.11.0",
+    "cors": "^2.8.5",
+    "helmet": "^7.0.0"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -8,14 +8,14 @@ const passwordSchema = Joi.object({
   password: Joi.string().min(8).required()
 });
 
-router.post('/hash', validate(passwordSchema), (req, res) => {
+router.post('/hash', validate(passwordSchema), (req, res, next) => {
   try {
     const { password } = req.body; // already sanitized in middleware
     const salt = randomBytes(16).toString('hex');
     const hash = scryptSync(password, salt, 64).toString('hex');
     res.json({ hash: `${salt}:${hash}` });
   } catch (err) {
-    res.status(500).json({ error: 'Error hashing password' });
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- add cors and helmet middleware to express server
- centralize error handling with logging for unexpected failures
- forward hashing errors to the new handler

## Testing
- `npm test` (backend)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b84daeab908328807fa7e0c78c7f16