### PR TITLE
feat: use async scrypt hashing in auth route

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,21 +1,24 @@
 const express = require('express');
 const router = express.Router();
 const Joi = require('joi');
-const { randomBytes, scryptSync } = require('crypto');
+const { randomBytes, scrypt } = require('crypto');
+const { promisify } = require('util');
 const validate = require('../middleware/validate');
 
 const passwordSchema = Joi.object({
   password: Joi.string().min(8).required()
 });
 
-router.post('/hash', validate(passwordSchema), (req, res) => {
+const scryptAsync = promisify(scrypt);
+
+router.post('/hash', validate(passwordSchema), async (req, res) => {
   try {
     const { password } = req.body; // already sanitized in middleware
     const salt = randomBytes(16).toString('hex');
-    const hash = scryptSync(password, salt, 64).toString('hex');
-    res.json({ hash: `${salt}:${hash}` });
+    const hash = await scryptAsync(password, salt, 64);
+    res.json({ hash: `${salt}:${hash.toString('hex')}` });
   } catch (err) {
-    res.status(500).json({ error: 'Error hashing password' });
+    res.status(500).json({ error: `Error hashing password: ${err.message}` });
   }
 });
 


### PR DESCRIPTION
## Summary
- replace synchronous `scryptSync` with promisified `crypto.scrypt`
- improve error handling for hash failures and add file-end newline

## Testing
- `npm test` (backend)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b84d2444ec83288ca19180e82ab8a4