### PR TITLE
chore: gate console logs behind debug flag

### DIFF
--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -9,6 +9,8 @@ import { Star, MapPin, Clock, Search, Filter } from 'lucide-react';
 import PriceNegotiation from '@/components/PriceNegotiation';
 import { supabase } from '@/lib/supabase';
 
+const DEBUG = import.meta.env.DEV;
+
 interface Freelancer {
   id: string;
   name: string;
@@ -197,7 +199,7 @@ export const FreelancerDirectory = () => {
                     serviceTitle={`${freelancer.name} - ${freelancer.title}`}
                     providerId={freelancer.id.toString()}
                     onNegotiationComplete={(finalPrice) => {
-                      console.log(`Negotiation complete: $${finalPrice}`);
+                      if (DEBUG) console.log(`Negotiation complete: $${finalPrice}`);
                     }}
                   />
                 </DialogContent>
@@ -232,3 +234,4 @@ export const FreelancerDirectory = () => {
     </div>
   );
 };
+

--- a/src/components/funding/FundingHub.tsx
+++ b/src/components/funding/FundingHub.tsx
@@ -8,6 +8,8 @@ import { OpportunityCard } from './OpportunityCard';
 import { supabase } from '@/lib/supabase';
 import { Search, Filter, Sparkles } from 'lucide-react';
 
+const DEBUG = import.meta.env.DEV;
+
 interface FundingOpportunity {
   id: string;
   title: string;
@@ -50,12 +52,12 @@ export const FundingHub = () => {
   };
   const handleApply = async (opportunityId: string) => {
     // Implementation for application process
-    console.log('Applying for opportunity:', opportunityId);
+    if (DEBUG) console.log('Applying for opportunity:', opportunityId);
   };
 
   const handleGetHelp = async (opportunityId: string) => {
     // Implementation for getting professional help
-    console.log('Getting help for opportunity:', opportunityId);
+    if (DEBUG) console.log('Getting help for opportunity:', opportunityId);
   };
 
   const filteredOpportunities = opportunities.filter(opp => {

--- a/src/components/investor/SMEDirectory.tsx
+++ b/src/components/investor/SMEDirectory.tsx
@@ -7,6 +7,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { supabase } from '@/lib/supabase';
 import { Search, MapPin, Users, TrendingUp, Heart, DollarSign } from 'lucide-react';
 
+const DEBUG = import.meta.env.DEV;
+
 interface SME {
   id: string;
   business_name: string;
@@ -57,7 +59,7 @@ const SMEDirectory = () => {
 
   const handleShowInterest = (smeId: string, type: 'investment' | 'donation') => {
     // This will be handled by the InterestModal component
-    console.log(`Showing ${type} interest in SME:`, smeId);
+    if (DEBUG) console.log(`Showing ${type} interest in SME:`, smeId);
   };
 
   if (loading) {

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -11,6 +11,8 @@ import { IntegratedMarketplace } from '@/components/marketplace/IntegratedMarket
 import { ComplianceGate } from '@/components/marketplace/ComplianceGate';
 import { SubscriptionBanner } from '@/components/SubscriptionBanner';
 
+const DEBUG = import.meta.env.DEV;
+
 // Products will be fetched from database in production
 
 const Marketplace = () => {
@@ -30,15 +32,15 @@ const Marketplace = () => {
   };
 
   const handleViewDetails = (product: any) => {
-    console.log('View product details:', product);
+    if (DEBUG) console.log('View product details:', product);
   };
 
   const handleSelectRecommendation = (recommendation: any) => {
-    console.log('Selected recommendation:', recommendation);
+    if (DEBUG) console.log('Selected recommendation:', recommendation);
   };
 
   const handlePriceSelect = (price: number) => {
-    console.log('Selected price:', price);
+    if (DEBUG) console.log('Selected price:', price);
   };
 
   return (


### PR DESCRIPTION
## Summary
- guard marketplace action logs behind `import.meta.env.DEV`
- wrap debug messages in FundingHub, FreelancerDirectory, and SMEDirectory with a DEBUG flag

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b84d1c73b883288ec77cf5b2f95d09