### PR TITLE
feat: add service request service

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -173,6 +173,19 @@ Manages payment transactions:
 - updated_at: TIMESTAMP
 ```
 
+#### `service_requests` Table
+```sql
+- id: UUID (Primary Key)
+- user_id: UUID (References profiles.id)
+- title: TEXT
+- description: TEXT
+- skills: TEXT[]
+- willing_to_pay: BOOLEAN
+- budget: NUMERIC
+- created_at: TIMESTAMP
+- updated_at: TIMESTAMP
+```
+
 ## Usage Examples
 
 ### Basic User Operations

--- a/scripts/validate-database.ts
+++ b/scripts/validate-database.ts
@@ -38,7 +38,8 @@ const {
   healthCheck,
   userService,
   profileService,
-  subscriptionService
+  subscriptionService,
+  serviceRequestService
 } = await import('../src/lib/services/index');
 
 // Colors for console output
@@ -129,6 +130,7 @@ async function validateServices() {
     { name: 'userService', service: userService },
     { name: 'profileService', service: profileService },
     { name: 'subscriptionService', service: subscriptionService },
+    { name: 'serviceRequestService', service: serviceRequestService },
   ];
   
   let allValid = true;

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -187,6 +187,18 @@ export interface Service {
   updated_at: string;
 }
 
+export interface ServiceRequest {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  skills: string[];
+  willing_to_pay: boolean;
+  budget?: number;
+  created_at: string;
+  updated_at: string;
+}
+
 // ================================
 // Connection and Messaging Types
 // ================================

--- a/src/lib/services/__tests__/database-services.test.ts
+++ b/src/lib/services/__tests__/database-services.test.ts
@@ -47,15 +47,17 @@ describe('Database Services', () => {
       expect(services.profileService).toBeDefined();
       expect(services.subscriptionService).toBeDefined();
       expect(services.transactionService).toBeDefined();
+      expect(services.serviceRequestService).toBeDefined();
       expect(services.supabase).toBeDefined();
     });
 
     it('should have proper service types', async () => {
-      const { userService, profileService, subscriptionService } = await import('../index');
-      
+      const { userService, profileService, subscriptionService, serviceRequestService } = await import('../index');
+
       expect(typeof userService).toBe('object');
       expect(typeof profileService).toBe('object');
       expect(typeof subscriptionService).toBe('object');
+      expect(typeof serviceRequestService).toBe('object');
     });
   });
 
@@ -86,6 +88,15 @@ describe('Database Services', () => {
       expect(typeof subscriptionService.getCurrentUserSubscription).toBe('function');
       expect(typeof subscriptionService.createSubscription).toBe('function');
       expect(typeof subscriptionService.hasActiveSubscription).toBe('function');
+    });
+
+    it('should have expected methods on service request service', async () => {
+      const { serviceRequestService } = await import('../index');
+
+      expect(typeof serviceRequestService.create).toBe('function');
+      expect(typeof serviceRequestService.findMany).toBe('function');
+      expect(typeof serviceRequestService.findById).toBe('function');
+      expect(typeof serviceRequestService.delete).toBe('function');
     });
   });
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -16,12 +16,18 @@ export {
 } from './user-service';
 
 // Subscription services
-export { 
-  SubscriptionService, 
-  TransactionService, 
-  subscriptionService, 
-  transactionService 
+export {
+  SubscriptionService,
+  TransactionService,
+  subscriptionService,
+  transactionService
 } from './subscription-service';
+
+// Service Request service
+export {
+  ServiceRequestService,
+  serviceRequestService
+} from './service-request-service';
 
 // Enhanced Supabase client and utilities
 export { 
@@ -41,10 +47,13 @@ import {
   userService, 
   profileService 
 } from './user-service';
-import { 
-  subscriptionService, 
-  transactionService 
+import {
+  subscriptionService,
+  transactionService
 } from './subscription-service';
+import {
+  serviceRequestService
+} from './service-request-service';
 
 // Utility functions for common patterns
 export const createServiceInstance = <T>(ServiceClass: new () => T): T => {
@@ -57,6 +66,7 @@ export const serviceRegistry = {
   profile: profileService,
   subscription: subscriptionService,
   transaction: transactionService,
+  serviceRequest: serviceRequestService,
 } as const;
 
 export type ServiceType = keyof typeof serviceRegistry;

--- a/src/lib/services/service-request-service.ts
+++ b/src/lib/services/service-request-service.ts
@@ -1,0 +1,41 @@
+/**
+ * Service Request service for handling service request operations
+ */
+
+import { BaseService } from './base-service';
+import type {
+  ServiceRequest,
+  DatabaseResponse,
+  PaginatedResponse,
+  PaginationParams
+} from '@/@types/database';
+
+export class ServiceRequestService extends BaseService<ServiceRequest> {
+  constructor() {
+    super('service_requests');
+  }
+
+  create(data: Partial<ServiceRequest>): Promise<DatabaseResponse<ServiceRequest>> {
+    return super.create(data);
+  }
+
+  findMany(
+    filters: Record<string, any> = {},
+    pagination: PaginationParams = {},
+    select: string = '*'
+  ): Promise<DatabaseResponse<PaginatedResponse<ServiceRequest>>> {
+    return super.findMany(filters, pagination, select);
+  }
+
+  findById(id: string, select: string = '*'): Promise<DatabaseResponse<ServiceRequest>> {
+    return super.findById(id, select);
+  }
+
+  delete(id: string): Promise<DatabaseResponse<void>> {
+    return super.delete(id);
+  }
+}
+
+export const serviceRequestService = new ServiceRequestService();
+
+export default serviceRequestService;


### PR DESCRIPTION
## Summary
- add `service_requests` table docs and TypeScript types
- implement `ServiceRequestService` with CRUD helpers
- expose service request service through service index and validation script

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:jest src/lib/services/__tests__/database-services.test.ts` *(fails: Cannot find module '@supabase/supabase-js' and 'import.meta' meta-property errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b87623d6a083288b25b04cc63f777a