### PR TITLE
feat: add service requests page and service

### DIFF
--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -188,6 +188,22 @@ export interface Service {
 }
 
 // ================================
+// Service Request Types
+// ================================
+
+export interface ServiceRequest {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  skills: string[];
+  willing_to_pay: boolean;
+  budget?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// ================================
 // Connection and Messaging Types
 // ================================
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import ServiceRequests from "./pages/ServiceRequests";
 import FeedbackWidget from "@/components/FeedbackWidget";
 
 const queryClient = new QueryClient();
@@ -38,6 +39,7 @@ export const AppRoutes = () => (
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/terms-of-service" element={<TermsOfService />} />
     <Route path="/messages" element={<Messages />} />
+    <Route path="/service-requests" element={<ServiceRequests />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/lib/services/__tests__/database-services.test.ts
+++ b/src/lib/services/__tests__/database-services.test.ts
@@ -42,20 +42,22 @@ describe('Database Services', () => {
   describe('Service Imports', () => {
     it('should import all services without errors', async () => {
       const services = await import('../index');
-      
+
       expect(services.userService).toBeDefined();
       expect(services.profileService).toBeDefined();
       expect(services.subscriptionService).toBeDefined();
       expect(services.transactionService).toBeDefined();
+      expect(services.serviceRequestService).toBeDefined();
       expect(services.supabase).toBeDefined();
     });
 
     it('should have proper service types', async () => {
-      const { userService, profileService, subscriptionService } = await import('../index');
-      
+      const { userService, profileService, subscriptionService, serviceRequestService } = await import('../index');
+
       expect(typeof userService).toBe('object');
       expect(typeof profileService).toBe('object');
       expect(typeof subscriptionService).toBe('object');
+      expect(typeof serviceRequestService).toBe('object');
     });
   });
 
@@ -86,6 +88,15 @@ describe('Database Services', () => {
       expect(typeof subscriptionService.getCurrentUserSubscription).toBe('function');
       expect(typeof subscriptionService.createSubscription).toBe('function');
       expect(typeof subscriptionService.hasActiveSubscription).toBe('function');
+    });
+
+    it('should have expected methods on service request service', async () => {
+      const { serviceRequestService } = await import('../index');
+
+      expect(typeof serviceRequestService.getRequestsByUser).toBe('function');
+      expect(typeof serviceRequestService.createRequest).toBe('function');
+      expect(typeof serviceRequestService.updateRequest).toBe('function');
+      expect(typeof serviceRequestService.deleteRequest).toBe('function');
     });
   });
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -16,12 +16,18 @@ export {
 } from './user-service';
 
 // Subscription services
-export { 
-  SubscriptionService, 
-  TransactionService, 
-  subscriptionService, 
-  transactionService 
+export {
+  SubscriptionService,
+  TransactionService,
+  subscriptionService,
+  transactionService
 } from './subscription-service';
+
+// Service request services
+export {
+  ServiceRequestService,
+  serviceRequestService
+} from './service-request-service';
 
 // Enhanced Supabase client and utilities
 export { 
@@ -41,10 +47,13 @@ import {
   userService, 
   profileService 
 } from './user-service';
-import { 
-  subscriptionService, 
-  transactionService 
+import {
+  subscriptionService,
+  transactionService
 } from './subscription-service';
+import {
+  serviceRequestService
+} from './service-request-service';
 
 // Utility functions for common patterns
 export const createServiceInstance = <T>(ServiceClass: new () => T): T => {
@@ -57,6 +66,7 @@ export const serviceRegistry = {
   profile: profileService,
   subscription: subscriptionService,
   transaction: transactionService,
+  serviceRequest: serviceRequestService,
 } as const;
 
 export type ServiceType = keyof typeof serviceRegistry;

--- a/src/lib/services/service-request-service.ts
+++ b/src/lib/services/service-request-service.ts
@@ -1,0 +1,56 @@
+/**
+ * Service Request service for handling service request operations
+ */
+
+import { BaseService } from './base-service';
+import { supabase, withErrorHandling } from '@/lib/supabase-enhanced';
+import type { ServiceRequest, DatabaseResponse } from '@/@types/database';
+
+export class ServiceRequestService extends BaseService<ServiceRequest> {
+  constructor() {
+    super('service_requests');
+  }
+
+  /**
+   * Get service requests submitted by a specific user
+   */
+  async getRequestsByUser(userId: string): Promise<DatabaseResponse<ServiceRequest[]>> {
+    return withErrorHandling(
+      () =>
+        supabase
+          .from(this.tableName)
+          .select('*')
+          .eq('user_id', userId)
+          .order('created_at', { ascending: false }),
+      'ServiceRequestService.getRequestsByUser'
+    );
+  }
+
+  /**
+   * Create a new service request
+   */
+  async createRequest(
+    request: Omit<ServiceRequest, 'id' | 'created_at' | 'updated_at'>
+  ): Promise<DatabaseResponse<ServiceRequest>> {
+    return this.create(request);
+  }
+
+  /**
+   * Update an existing service request
+   */
+  async updateRequest(
+    id: string,
+    data: Partial<ServiceRequest>
+  ): Promise<DatabaseResponse<ServiceRequest>> {
+    return this.update(id, data);
+  }
+
+  /**
+   * Delete a service request
+   */
+  async deleteRequest(id: string): Promise<DatabaseResponse<void>> {
+    return super.delete(id);
+  }
+}
+
+export const serviceRequestService = new ServiceRequestService();

--- a/src/pages/ServiceRequests.tsx
+++ b/src/pages/ServiceRequests.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect, useCallback, FormEvent } from 'react';
+import AppLayout from '@/components/AppLayout';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { serviceRequestService } from '@/lib/services';
+import { useAppContext } from '@/contexts/AppContext';
+import type { ServiceRequest } from '@/@types/database';
+
+const ServiceRequests = () => {
+  const { user } = useAppContext();
+  const { toast } = useToast();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [skills, setSkills] = useState('');
+  const [willingToPay, setWillingToPay] = useState(false);
+  const [budget, setBudget] = useState('');
+  const [requests, setRequests] = useState<ServiceRequest[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const loadRequests = useCallback(async () => {
+    if (!user) return;
+    const { data, error } = await serviceRequestService.getRequestsByUser(user.id);
+    if (error) {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    } else if (data) {
+      setRequests(data);
+    }
+  }, [user, toast]);
+
+  useEffect(() => {
+    loadRequests();
+  }, [loadRequests]);
+
+  const resetForm = () => {
+    setTitle('');
+    setDescription('');
+    setSkills('');
+    setWillingToPay(false);
+    setBudget('');
+    setEditingId(null);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    const payload = {
+      user_id: user.id,
+      title,
+      description,
+      skills: skills.split(',').map(s => s.trim()).filter(Boolean),
+      willing_to_pay: willingToPay,
+      budget: willingToPay ? Number(budget) : undefined,
+    };
+
+    const result = editingId
+      ? await serviceRequestService.updateRequest(editingId, payload)
+      : await serviceRequestService.createRequest(payload);
+
+    if (result.error) {
+      toast({ title: 'Error', description: result.error.message, variant: 'destructive' });
+    } else {
+      toast({ title: 'Success', description: editingId ? 'Request updated.' : 'Request submitted.' });
+      resetForm();
+      loadRequests();
+    }
+  };
+
+  const handleEdit = (request: ServiceRequest) => {
+    setEditingId(request.id);
+    setTitle(request.title);
+    setDescription(request.description);
+    setSkills(request.skills.join(', '));
+    setWillingToPay(request.willing_to_pay);
+    setBudget(request.budget?.toString() || '');
+  };
+
+  const handleDelete = async (id: string) => {
+    const { error } = await serviceRequestService.deleteRequest(id);
+    if (error) {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    } else {
+      toast({ title: 'Deleted', description: 'Request removed.' });
+      loadRequests();
+    }
+  };
+
+  return (
+    <AppLayout>
+      <div className="max-w-3xl mx-auto py-8 px-4">
+        <h1 className="text-2xl font-bold mb-4">Service Requests</h1>
+        <form onSubmit={handleSubmit} className="space-y-4 mb-8">
+          <Input
+            placeholder="Service title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
+          <Textarea
+            placeholder="Detailed description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+          <Input
+            placeholder="Required skills or tags (comma separated)"
+            value={skills}
+            onChange={e => setSkills(e.target.value)}
+          />
+          <div className="flex items-center space-x-2">
+            <Switch checked={willingToPay} onCheckedChange={setWillingToPay} id="pay-switch" />
+            <label htmlFor="pay-switch">Willing to pay</label>
+          </div>
+          {willingToPay && (
+            <Input
+              type="number"
+              placeholder="Budget"
+              value={budget}
+              onChange={e => setBudget(e.target.value)}
+            />
+          )}
+          <Button type="submit">{editingId ? 'Update Request' : 'Submit Request'}</Button>
+        </form>
+
+        <div className="space-y-4">
+          {requests.map(req => (
+            <div key={req.id} className="border rounded p-4">
+              <div className="flex justify-between">
+                <div>
+                  <h2 className="font-semibold">{req.title}</h2>
+                  <p className="text-sm text-gray-600 mb-2">{req.description}</p>
+                  <p className="text-sm text-gray-600">Skills: {req.skills.join(', ')}</p>
+                  {req.willing_to_pay && (
+                    <p className="text-sm text-gray-600">Budget: {req.budget}</p>
+                  )}
+                </div>
+                <div className="space-x-2">
+                  <Button variant="outline" size="sm" onClick={() => handleEdit(req)}>
+                    Edit
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={() => handleDelete(req.id)}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+          {requests.length === 0 && (
+            <p className="text-sm text-gray-600">No requests submitted yet.</p>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default ServiceRequests;


### PR DESCRIPTION
## Summary
- add service request types and service layer
- expose service requests page for submitting and managing requests
- extend tests and exports for new service

## Testing
- `npm test`
- `npm run test:jest` *(fails: Cannot find module '../lib/services' and other TS errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87619353883289b22e7543a80d0dd