### PR TITLE
Add About page and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AppProvider } from "@/contexts/AppContext";
 import Index from "./pages/Index";
 import Marketplace from "./pages/Marketplace";
 import Resources from "./pages/Resources";
+import About from "./pages/About";
 import NotFound from "./pages/NotFound";
 import { SignIn } from "./pages/SignIn";
 import { GetStarted } from "./pages/GetStarted";
@@ -29,6 +30,7 @@ export const AppRoutes = () => (
     <Route path="/marketplace" element={<Marketplace />} />
     <Route path="/freelancer-hub" element={<FreelancerHub />} />
     <Route path="/resources" element={<Resources />} />
+    <Route path="/about" element={<About />} />
     <Route path="/signin" element={<SignIn />} />
     <Route path="/get-started" element={<GetStarted />} />
     <Route path="/profile-setup" element={<ProfileSetup />} />

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -7,6 +7,7 @@ import { AppRoutes } from '../App';
 jest.mock('../pages/Index', () => ({ default: () => <div>Home Page</div> }));
 jest.mock('../pages/Marketplace', () => ({ default: () => <div>Marketplace Page</div> }));
 jest.mock('../pages/Resources', () => ({ default: () => <div>Resources Page</div> }));
+jest.mock('../pages/About', () => ({ default: () => <div>About Page</div> }));
 jest.mock('../pages/NotFound', () => ({ default: () => <div>Not Found</div> }));
 jest.mock('../pages/SignIn', () => ({ SignIn: () => <div>Sign In Page</div> }));
 jest.mock('../pages/GetStarted', () => ({ GetStarted: () => <div>Get Started Page</div> }));
@@ -24,6 +25,7 @@ const routes = [
   { path: '/marketplace', text: 'Marketplace Page' },
   { path: '/freelancer-hub', text: 'Freelancer Hub Page' },
   { path: '/resources', text: 'Resources Page' },
+  { path: '/about', text: 'About Page' },
   { path: '/signin', text: 'Sign In Page' },
   { path: '/get-started', text: 'Get Started Page' },
   { path: '/profile-setup', text: 'Profile Setup Page' },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,7 @@ const Header = () => {
     { name: 'Marketplace', href: '/marketplace' },
     { name: 'Freelancer Hub', href: '/freelancer-hub' },
     { name: 'Resources', href: '/resources' },
+    { name: 'About', href: '/about' },
     { name: 'Partnership Hub', href: '/partnership-hub' }
   ];
 

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -41,7 +41,7 @@ describe('Header', () => {
 
     renderHeader();
 
-    const navLinks = ['Home', 'Marketplace', 'Freelancer Hub', 'Resources', 'Partnership Hub'];
+      const navLinks = ['Home', 'Marketplace', 'Freelancer Hub', 'Resources', 'About', 'Partnership Hub'];
     navLinks.forEach((text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,14 @@
+import AppLayout from '@/components/AppLayout';
+
+const About = () => (
+  <AppLayout>
+    <div className="max-w-6xl mx-auto px-6 py-12">
+      <h1 className="text-4xl font-bold mb-4">About Us</h1>
+      <p className="text-lg text-gray-700">
+        Learn more about WATHACI CONNECT and our mission.
+      </p>
+    </div>
+  </AppLayout>
+);
+
+export default About;


### PR DESCRIPTION
## Summary
- add About page component and route
- link About page from header navigation
- update tests for new route

## Testing
- `npm test`
- `npm run test:jest` *(fails: TS errors in existing test setup)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b870cf33c483288219e7b7a47e0cbb