### PR TITLE
feat: add scroll reveal hook and about page animations

### DIFF
--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * useScrollReveal
+ * Intersection Observer hook that fades elements in when they scroll into view.
+ *
+ * Usage:
+ * const ref = useScrollReveal();
+ * return <div ref={ref} className="opacity-0">Content</div>;
+ */
+export function useScrollReveal(options?: IntersectionObserverInit) {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          node.classList.add("animate-fade-in");
+          node.classList.remove("opacity-0");
+          observer.unobserve(node);
+        }
+      },
+      { threshold: 0.1, ...options }
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [options]);
+
+  return ref;
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,40 @@
+import AppLayout from "@/components/AppLayout";
+import { useScrollReveal } from "@/hooks/useScrollReveal";
+
+const About = () => {
+  const missionRef = useScrollReveal();
+  const visionRef = useScrollReveal();
+  const teamRef = useScrollReveal();
+
+  return (
+    <AppLayout>
+      <div className="container mx-auto px-4 py-16 space-y-32">
+        <section ref={missionRef} className="opacity-0">
+          <h2 className="text-3xl font-bold mb-4">Our Mission</h2>
+          <p className="text-lg text-muted-foreground">
+            We aim to empower businesses with tools and resources that make
+            compliance simple and growth achievable.
+          </p>
+        </section>
+
+        <section ref={visionRef} className="opacity-0">
+          <h2 className="text-3xl font-bold mb-4">Our Vision</h2>
+          <p className="text-lg text-muted-foreground">
+            To be the leading platform connecting entrepreneurs with services
+            and knowledge across the region.
+          </p>
+        </section>
+
+        <section ref={teamRef} className="opacity-0">
+          <h2 className="text-3xl font-bold mb-4">Our Team</h2>
+          <p className="text-lg text-muted-foreground">
+            Our diverse team combines expertise in technology, finance, and law
+            to support our community.
+          </p>
+        </section>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default About;


### PR DESCRIPTION
## Summary
- add Intersection Observer hook for scroll-based fade-ins
- create About page sections that reveal on scroll

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b870eeff108328a1d482486c8faf58