### PR TITLE
feat: add team filter hook and about page search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import FreelancerHub from "./pages/FreelancerHub";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import Messages from "./pages/Messages";
+import About from "./pages/About";
 import FeedbackWidget from "@/components/FeedbackWidget";
 
 const queryClient = new QueryClient();
@@ -29,6 +30,7 @@ export const AppRoutes = () => (
     <Route path="/marketplace" element={<Marketplace />} />
     <Route path="/freelancer-hub" element={<FreelancerHub />} />
     <Route path="/resources" element={<Resources />} />
+    <Route path="/about" element={<About />} />
     <Route path="/signin" element={<SignIn />} />
     <Route path="/get-started" element={<GetStarted />} />
     <Route path="/profile-setup" element={<ProfileSetup />} />

--- a/src/__tests__/AppRoutes.test.tsx
+++ b/src/__tests__/AppRoutes.test.tsx
@@ -18,12 +18,14 @@ jest.mock('../pages/FreelancerHub', () => ({ default: () => <div>Freelancer Hub 
 jest.mock('../pages/PrivacyPolicy', () => ({ default: () => <div>Privacy Policy Page</div> }));
 jest.mock('../pages/TermsOfService', () => ({ default: () => <div>Terms Of Service Page</div> }));
 jest.mock('../pages/Messages', () => ({ default: () => <div>Messages Page</div> }));
+jest.mock('../pages/About', () => ({ default: () => <div>About Page</div> }));
 
 const routes = [
   { path: '/', text: 'Home Page' },
   { path: '/marketplace', text: 'Marketplace Page' },
   { path: '/freelancer-hub', text: 'Freelancer Hub Page' },
   { path: '/resources', text: 'Resources Page' },
+  { path: '/about', text: 'About Page' },
   { path: '/signin', text: 'Sign In Page' },
   { path: '/get-started', text: 'Get Started Page' },
   { path: '/profile-setup', text: 'Profile Setup Page' },

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -1,0 +1,31 @@
+export interface TeamMember {
+  name: string;
+  role: string;
+  expertise: string[];
+  image?: string;
+}
+
+export const teamMembers: TeamMember[] = [
+  {
+    name: 'Alice Mwila',
+    role: 'CEO',
+    expertise: ['Leadership', 'Strategy'],
+  },
+  {
+    name: 'Brian Zulu',
+    role: 'CTO',
+    expertise: ['Frontend', 'Backend', 'DevOps'],
+  },
+  {
+    name: 'Chipo Banda',
+    role: 'Designer',
+    expertise: ['UI', 'UX', 'Frontend'],
+  },
+  {
+    name: 'Diana Phiri',
+    role: 'Marketing',
+    expertise: ['Marketing', 'Content'],
+  },
+];
+
+export default teamMembers;

--- a/src/hooks/use-team-filter.ts
+++ b/src/hooks/use-team-filter.ts
@@ -1,0 +1,33 @@
+import { useState, useMemo } from 'react';
+import type { TeamMember } from '@/data/team';
+
+export function useTeamFilter(members: TeamMember[]) {
+  const [query, setQuery] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+
+  const toggleTag = (tag: string) => {
+    setTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const filtered = useMemo(() => {
+    const lower = query.toLowerCase();
+    return members.filter(member => {
+      const matchesQuery =
+        member.name.toLowerCase().includes(lower) ||
+        member.role.toLowerCase().includes(lower) ||
+        member.expertise.some(exp => exp.toLowerCase().includes(lower));
+
+      const matchesTags =
+        tags.length === 0 ||
+        tags.some(tag => member.role === tag || member.expertise.includes(tag));
+
+      return matchesQuery && matchesTags;
+    });
+  }, [members, query, tags]);
+
+  return { query, setQuery, tags, toggleTag, filteredMembers: filtered };
+}
+
+export default useTeamFilter;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,71 @@
+import AppLayout from '@/components/AppLayout';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import teamMembers from '@/data/team';
+import { useTeamFilter } from '@/hooks/use-team-filter';
+
+const allTags = Array.from(
+  new Set(teamMembers.flatMap(m => [m.role, ...m.expertise]))
+);
+
+const About = () => {
+  const {
+    query,
+    setQuery,
+    tags,
+    toggleTag,
+    filteredMembers,
+  } = useTeamFilter(teamMembers);
+
+  return (
+    <AppLayout>
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <h1 className="text-4xl font-bold mb-8">About Us</h1>
+
+        <div className="space-y-6 mb-8">
+          <Input
+            placeholder="Search team members..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {allTags.map(tag => (
+              <Badge
+                key={tag}
+                variant={tags.includes(tag) ? 'default' : 'outline'}
+                onClick={() => toggleTag(tag)}
+                className="cursor-pointer"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredMembers.map(member => (
+            <div key={member.name} className="p-6 border rounded-lg">
+              <h3 className="text-xl font-semibold mb-1">{member.name}</h3>
+              <p className="text-sm text-gray-600 mb-2">{member.role}</p>
+              <div className="flex flex-wrap gap-1">
+                {member.expertise.map(exp => (
+                  <Badge key={exp} variant="secondary">
+                    {exp}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ))}
+          {filteredMembers.length === 0 && (
+            <p className="col-span-full text-center text-gray-500">
+              No team members found.
+            </p>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default About;


### PR DESCRIPTION
## Summary
- create `useTeamFilter` hook to search and filter team by role/expertise
- add About page with search input and tag filters
- wire About route and update route tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b870f397b883288f6a7a1e20002fa3