### PR TITLE
Link expertise badges and prefilter by skill

### DIFF
--- a/src/components/FreelancerDirectory.tsx
+++ b/src/components/FreelancerDirectory.tsx
@@ -1,16 +1,12 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
-import { Star, MapPin, Clock, Search, Filter } from 'lucide-react';
-import PriceNegotiation from '@/components/PriceNegotiation';
+import { Search, Filter } from 'lucide-react';
+import { TeamMemberCard } from './TeamMemberCard';
 import { supabase } from '@/lib/supabase';
 import { logger } from '@/utils/logger';
-
-const DEBUG = import.meta.env.DEV;
 
 interface Freelancer {
   id: string;
@@ -29,8 +25,8 @@ interface Freelancer {
   years_experience: number;
 }
 
-export const FreelancerDirectory = () => {
-  const [searchTerm, setSearchTerm] = useState('');
+export const FreelancerDirectory = ({ initialSkill = '' }: { initialSkill?: string }) => {
+  const [searchTerm, setSearchTerm] = useState(initialSkill);
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedLocation, setSelectedLocation] = useState('');
   const [priceRange, setPriceRange] = useState('');
@@ -40,6 +36,10 @@ export const FreelancerDirectory = () => {
   useEffect(() => {
     fetchFreelancers();
   }, []);
+
+  useEffect(() => {
+    setSearchTerm(initialSkill);
+  }, [initialSkill]);
 
   const fetchFreelancers = async () => {
     try {
@@ -132,81 +132,7 @@ export const FreelancerDirectory = () => {
 
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredFreelancers.map((freelancer) => (
-          <Card key={freelancer.id} className="hover:shadow-lg transition-shadow">
-            <CardHeader className="text-center">
-              <img
-                src={freelancer.profile_image_url || '/placeholder.svg'}
-                alt={freelancer.name}
-                loading="lazy"
-                decoding="async"
-                className="w-20 h-20 rounded-full mx-auto mb-4 object-cover"
-              />
-              <CardTitle className="text-xl">{freelancer.name}</CardTitle>
-              <p className="text-gray-600">{freelancer.title}</p>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-1">
-                  <Star className="w-4 h-4 text-yellow-500 fill-current" />
-                  <span className="font-semibold">{freelancer.rating}</span>
-                  <span className="text-gray-500">({freelancer.reviews_count})</span>
-                </div>
-                <div className="flex items-center gap-1 text-gray-500">
-                  <MapPin className="w-4 h-4" />
-                  <span>{freelancer.location}</span>
-                </div>
-              </div>
-              
-              <div className="mb-4">
-                <div className="flex flex-wrap gap-1 mb-2">
-                  {freelancer.skills.slice(0, 3).map((skill, idx) => (
-                    <Badge key={idx} variant="secondary" className="text-xs">
-                      {skill}
-                    </Badge>
-                  ))}
-                  {freelancer.skills.length > 3 && (
-                    <Badge variant="outline" className="text-xs">
-                      +{freelancer.skills.length - 3}
-                    </Badge>
-                  )}
-                </div>
-              </div>
-              
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <span className="text-2xl font-bold text-blue-600">${freelancer.hourly_rate}</span>
-                  <span className="text-gray-500">/hour</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <Clock className="w-4 h-4 text-gray-400" />
-                  <span className={`text-sm ${freelancer.availability_status === 'available' ? 'text-green-600' : 'text-orange-600'}`}>
-                    {freelancer.availability_status === 'available' ? 'Available' : 'Busy'}
-                  </span>
-                </div>
-              </div>
-              
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button 
-                    className="w-full bg-orange-600 hover:bg-orange-700" 
-                    disabled={freelancer.availability_status !== 'available'}
-                  >
-                    {freelancer.availability_status === 'available' ? 'Hire & Negotiate' : 'Join Waitlist'}
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-4xl">
-                  <PriceNegotiation
-                    initialPrice={freelancer.hourly_rate}
-                    serviceTitle={`${freelancer.name} - ${freelancer.title}`}
-                    providerId={freelancer.id.toString()}
-                    onNegotiationComplete={(finalPrice) => {
-                      if (DEBUG) console.log(`Negotiation complete: $${finalPrice}`);
-                    }}
-                  />
-                </DialogContent>
-              </Dialog>
-            </CardContent>
-          </Card>
+          <TeamMemberCard key={freelancer.id} freelancer={freelancer} />
         ))}
       </div>
 

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -1,0 +1,121 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+import { Star, MapPin, Clock } from 'lucide-react';
+import PriceNegotiation from '@/components/PriceNegotiation';
+import { Link } from 'react-router-dom';
+
+const DEBUG = import.meta.env.DEV;
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  title: string;
+  bio?: string;
+  skills: string[];
+  hourly_rate: number;
+  currency: string;
+  location: string;
+  rating: number;
+  reviews_count: number;
+  profile_image_url?: string;
+  availability_status: string;
+}
+
+interface TeamMemberCardProps {
+  freelancer: TeamMember;
+}
+
+export const TeamMemberCard = ({ freelancer }: TeamMemberCardProps) => {
+  return (
+    <Card className="hover:shadow-lg transition-shadow">
+      <CardHeader className="text-center">
+        <img
+          src={freelancer.profile_image_url || '/placeholder.svg'}
+          alt={freelancer.name}
+          loading="lazy"
+          decoding="async"
+          className="w-20 h-20 rounded-full mx-auto mb-4 object-cover"
+        />
+        <CardTitle className="text-xl">{freelancer.name}</CardTitle>
+        <p className="text-gray-600">{freelancer.title}</p>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-1">
+            <Star className="w-4 h-4 text-yellow-500 fill-current" />
+            <span className="font-semibold">{freelancer.rating}</span>
+            <span className="text-gray-500">({freelancer.reviews_count})</span>
+          </div>
+          <div className="flex items-center gap-1 text-gray-500">
+            <MapPin className="w-4 h-4" />
+            <span>{freelancer.location}</span>
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <div className="flex flex-wrap gap-1 mb-2">
+            {freelancer.skills.slice(0, 3).map((skill) => (
+              <div key={skill} className="flex gap-1">
+                <Link to={`/marketplace?skill=${encodeURIComponent(skill)}`}>
+                  <Badge variant="secondary" className="text-xs">
+                    {skill}
+                  </Badge>
+                </Link>
+                <Link to={`/freelancer-hub?skill=${encodeURIComponent(skill)}`}>
+                  <Badge variant="outline" className="text-xs">
+                    {skill}
+                  </Badge>
+                </Link>
+              </div>
+            ))}
+            {freelancer.skills.length > 3 && (
+              <Badge variant="outline" className="text-xs">
+                +{freelancer.skills.length - 3}
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <span className="text-2xl font-bold text-blue-600">${freelancer.hourly_rate}</span>
+            <span className="text-gray-500">/hour</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock className="w-4 h-4 text-gray-400" />
+            <span
+              className={`text-sm ${freelancer.availability_status === 'available' ? 'text-green-600' : 'text-orange-600'}`}
+            >
+              {freelancer.availability_status === 'available' ? 'Available' : 'Busy'}
+            </span>
+          </div>
+        </div>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button
+              className="w-full bg-orange-600 hover:bg-orange-700"
+              disabled={freelancer.availability_status !== 'available'}
+            >
+              {freelancer.availability_status === 'available' ? 'Hire & Negotiate' : 'Join Waitlist'}
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-4xl">
+            <PriceNegotiation
+              initialPrice={freelancer.hourly_rate}
+              serviceTitle={`${freelancer.name} - ${freelancer.title}`}
+              providerId={freelancer.id.toString()}
+              onNegotiationComplete={(finalPrice) => {
+                if (DEBUG) console.log(`Negotiation complete: $${finalPrice}`);
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TeamMemberCard;

--- a/src/components/marketplace/IntegratedMarketplace.tsx
+++ b/src/components/marketplace/IntegratedMarketplace.tsx
@@ -27,10 +27,10 @@ interface Service {
   image: string;
 }
 
-export const IntegratedMarketplace = () => {
+export const IntegratedMarketplace = ({ initialSkill = '' }: { initialSkill?: string }) => {
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState(initialSkill);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedProviderType, setSelectedProviderType] = useState('all');
   const [selectedLocation, setSelectedLocation] = useState('all');
@@ -53,6 +53,10 @@ export const IntegratedMarketplace = () => {
   useEffect(() => {
     loadServices();
   }, [loadServices]);
+
+  useEffect(() => {
+    setSearchTerm(initialSkill);
+  }, [initialSkill]);
 
   const loadServices = useCallback(async () => {
     setLoading(true);

--- a/src/pages/FreelancerHub.tsx
+++ b/src/pages/FreelancerHub.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { FreelancerDirectory } from '@/components/FreelancerDirectory';
 import { FreelancerMatcher } from '@/components/FreelancerMatcher';
@@ -10,6 +11,8 @@ import { Users, Lightbulb, Heart, Target } from 'lucide-react';
 
 const FreelancerHub = () => {
   const [activeTab, setActiveTab] = useState('directory');
+  const [searchParams] = useSearchParams();
+  const skillFilter = searchParams.get('skill') || '';
 
   return (
     <AppLayout>
@@ -64,7 +67,7 @@ const FreelancerHub = () => {
                   Filter by skills, location, and budget to find your perfect match.
                 </p>
               </div>
-              <FreelancerDirectory />
+              <FreelancerDirectory initialSkill={skillFilter} />
             </TabsContent>
             <TabsContent value="industry" className="space-y-6">
               <div className="text-center mb-8">

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { MessageCircle, ShoppingCart, Users, Building, BookOpen } from 'lucide-react';
 import AppLayout from '@/components/AppLayout';
@@ -17,6 +18,8 @@ const DEBUG = import.meta.env.DEV;
 
 const Marketplace = () => {
   const [activeTab, setActiveTab] = useState('integrated');
+  const [searchParams] = useSearchParams();
+  const skillFilter = searchParams.get('skill') || '';
   const [searchQuery, setSearchQuery] = useState('');
   const [searchFilters, setSearchFilters] = useState({});
   const [cart, setCart] = useState<any[]>([]);
@@ -104,7 +107,7 @@ const Marketplace = () => {
                     Our AI analyzes qualifications and offerings to match you with the perfect service provider.
                   </p>
                 </div>
-                <IntegratedMarketplace />
+                <IntegratedMarketplace initialSkill={skillFilter} />
               </div>
             </ComplianceGate>
           )}


### PR DESCRIPTION
## Summary
- add `TeamMemberCard` with badges linking to marketplace and freelancer hub skill filters
- prefilter Marketplace and FreelancerHub pages by `skill` query param
- enable IntegratedMarketplace and FreelancerDirectory to accept initial skill filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b870fce4188328997a51448960adda