### PR TITLE
Track 404 page views

### DIFF
--- a/jest-tests/analytics.test.ts
+++ b/jest-tests/analytics.test.ts
@@ -1,0 +1,32 @@
+import { track } from '@/utils/analytics';
+
+describe('analytics track', () => {
+  afterEach(() => {
+    // @ts-ignore
+    global.fetch = undefined;
+    jest.resetAllMocks();
+  });
+
+  it('calls fetch with event data', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    await track('test-event', { foo: 'bar' });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: 'test-event', data: { foo: 'bar' } })
+    });
+  });
+
+  it('handles network errors gracefully', async () => {
+    const mockFetch = jest.fn().mockRejectedValue(new Error('network failure'));
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    await expect(track('error-event')).resolves.toBeUndefined();
+  });
+});
+

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,12 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { track } from "@/utils/analytics";
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    // TODO: integrate 404 tracking
+    track('404', { path: location.pathname });
   }, [location.pathname]);
 
   return (
@@ -22,3 +23,4 @@ const NotFound = () => {
 };
 
 export default NotFound;
+

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,28 @@
+interface AnalyticsEvent {
+  event: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Send analytics events to the backend.
+ * Network errors are caught to avoid cascading failures.
+ */
+export async function track(event: string, data: Record<string, unknown> = {}): Promise<void> {
+  try {
+    const response = await fetch('/api/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event, data } as AnalyticsEvent)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Analytics request failed with status ${response.status}`);
+    }
+  } catch (error) {
+    // Swallow network errors to prevent impacting the app
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Failed to send analytics event', { event, data, error });
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add analytics utility to send tracking events
- instrument NotFound page to record 404 paths
- cover analytics helper with tests

## Testing
- `npm test` *(fails: test files expecting Jest in node --test environment)*
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68b883166b388328a4acb36a3d8687d1