### PR TITLE
fix(header): add aria attributes to menu toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -120,6 +120,8 @@ const Header = () => {
 
           <button
             className="md:hidden p-2"
+            aria-label="Toggle navigation menu"
+            aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           >
             {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -89,13 +89,15 @@ describe('Header', () => {
       refreshUser: jest.fn(),
     });
 
-    const { container } = renderHeader();
+    renderHeader();
 
+    const toggle = screen.getByLabelText('Toggle navigation menu');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getAllByRole('navigation')).toHaveLength(1);
 
-    const toggle = screen.getAllByRole('button').find(btn => btn.textContent === '');
-    await userEvent.click(toggle!);
+    await userEvent.click(toggle);
 
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getAllByRole('navigation')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- add aria attributes to mobile menu toggle
- test mobile menu aria-expanded state changes

## Testing
- `npm run test:accessibility`
- `npm run test:jest -- --runTestsByPath src/components/__tests__/Header.test.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8831bf5c88328aca578a4eea3ec88