### PR TITLE
chore: add browser and lighthouse testing

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,32 @@
+name: Browser and Lighthouse Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npm run test:browser
+      - name: Run Lighthouse tests
+        run: npm run test:lighthouse
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+      - name: Upload Lighthouse report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: lighthouse-report.tap

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist/
 dist-ssr
 *.local
 
+# Test outputs
+playwright-report/
+lighthouse-report.tap
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "test:accessibility": "node --test test/accessibility.test.js",
-    "test:lighthouse": "node --test test/lighthouse.test.js"
+    "test:lighthouse": "node --test --test-reporter spec --test-reporter-destination stdout --test-reporter tap --test-reporter-destination lighthouse-report.tap test/lighthouse.test.js",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "@eslint/js": "^9.9.0",
@@ -104,6 +105,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@playwright/test": "^1.48.2"
   }
 }

--- a/playwright-tests/example.spec.ts
+++ b/playwright-tests/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Basic example test to verify page title
+// This helps track cross-browser behavior across runs.
+test('homepage has expected title', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example Domain/);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './playwright-tests',
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['json', { outputFile: 'playwright-report/test-results.json' }]
+  ],
+  use: {
+    trace: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+  ]
+});


### PR DESCRIPTION
## Summary
- configure Playwright for cross-browser tests and add sample spec
- record Lighthouse results and ignore generated reports
- add workflow to run browser and Lighthouse tests on PRs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run test:lighthouse`
- `npm run test:browser` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8833088748328a4dff28208f5956a