### PR TITLE
Add navigation and signup form tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,10 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
-  testMatch: ['<rootDir>/jest-tests/**/*.(test|spec).(ts|tsx)'],
+  testMatch: [
+    '<rootDir>/jest-tests/**/*.(test|spec).(ts|tsx)',
+    '<rootDir>/src/__tests__/(accessibility|navigation|forms).test.tsx'
+  ],
   collectCoverageFrom: [
     'src/**/*.(ts|tsx)',
     '!src/**/*.d.ts',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "node --test",
+    "test": "node --test && npm run test:jest",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "test:accessibility": "node --test test/accessibility.test.js",

--- a/src/__tests__/forms.test.tsx
+++ b/src/__tests__/forms.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, jest } from '@jest/globals';
+import { MemoryRouter } from 'react-router-dom';
+import { GetStarted } from '../pages/GetStarted';
+
+const mockSignUp = jest.fn().mockResolvedValue(undefined);
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// @ts-ignore
+global.ResizeObserver = MockResizeObserver;
+
+jest.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => ({ signUp: mockSignUp }),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ onValueChange, children }: any) => (
+    <select id="accountType" onChange={(e) => onValueChange(e.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: any) => <>{children}</>,
+  SelectValue: ({ placeholder }: any) => <option value="">{placeholder}</option>,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+}));
+
+describe('GetStarted form', () => {
+  it('submits form data', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <GetStarted />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText('First Name'), 'John');
+    await user.type(screen.getByLabelText('Last Name'), 'Doe');
+    await user.type(screen.getByLabelText('Email'), 'john@example.com');
+    await user.type(screen.getByLabelText('Company (Optional)'), 'Acme');
+    await user.selectOptions(screen.getByLabelText('Account Type'), 'professional');
+    await user.type(screen.getByLabelText('Password'), 'password123');
+    await user.type(screen.getByLabelText('Confirm Password'), 'password123');
+    await user.click(screen.getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(mockSignUp).toHaveBeenCalledWith('john@example.com', 'password123', {
+      first_name: 'John',
+      last_name: 'Doe',
+      company: 'Acme',
+      account_type: 'professional',
+      full_name: 'John Doe',
+      profile_completed: false,
+    });
+  });
+});

--- a/src/__tests__/navigation.test.tsx
+++ b/src/__tests__/navigation.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, jest } from '@jest/globals';
+
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+jest.mock('@/contexts/AppContext', () => ({
+  useAppContext: () => ({ user: null, signOut: jest.fn(), loading: false }),
+}));
+
+jest.mock('@/components/NotificationCenter', () => ({
+  NotificationCenter: () => <div />,
+}));
+
+jest.mock('@/components/DonateButton', () => ({
+  DonateButton: () => <button>Donate</button>,
+}));
+
+describe('Header navigation', () => {
+  const links = [
+    { name: 'Home', path: '/' },
+    { name: 'Marketplace', path: '/marketplace' },
+    { name: 'Freelancer Hub', path: '/freelancer-hub' },
+    { name: 'Resources', path: '/resources' },
+    { name: 'Partnership Hub', path: '/partnership-hub' },
+    { name: 'Get Started', path: '/get-started' },
+  ];
+
+  it.each(links)('navigates to %s', async ({ name, path }) => {
+    render(
+      <MemoryRouter initialEntries={['/initial']}>
+        <Header />
+        <Routes>
+          {links.map((r) => (
+            <Route key={r.path} path={r.path} element={<div>{r.name} Page</div>} />
+          ))}
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('link', { name }));
+    expect(screen.getByText(`${name} Page`)).toBeInTheDocument();
+  });
+});
+
+describe('Footer navigation', () => {
+  const links = [
+    { name: 'Marketplace', path: '/marketplace' },
+    { name: 'Freelancer Hub', path: '/freelancer-hub' },
+    { name: 'Partnership Hub', path: '/partnership-hub' },
+    { name: 'Resources', path: '/resources' },
+    { name: 'Get Started', path: '/get-started' },
+    { name: 'Privacy Policy', path: '/privacy-policy' },
+    { name: 'Terms of Service', path: '/terms-of-service' },
+  ];
+
+  it.each(links)('navigates to %s', async ({ name, path }) => {
+    render(
+      <MemoryRouter initialEntries={['/initial']}>
+        <Footer />
+        <Routes>
+          {links.map((r) => (
+            <Route key={r.path} path={r.path} element={<div>{r.name} Page</div>} />
+          ))}
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('link', { name }));
+    expect(screen.getByText(`${name} Page`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add navigation tests covering header and footer links
- verify GetStarted form submits expected signup data
- run Jest tests via npm test alongside Node test suites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b88326bbf08328a1b7667369e348e2