### PR TITLE
Add Playwright browser test scaffolding

### DIFF
--- a/jest-tests/analytics.test.ts
+++ b/jest-tests/analytics.test.ts
@@ -2,14 +2,14 @@ import { track } from '@/utils/analytics';
 
 describe('analytics track', () => {
   afterEach(() => {
-    // @ts-ignore
+    // @ts-expect-error - reset fetch after each test
     global.fetch = undefined;
     jest.resetAllMocks();
   });
 
   it('calls fetch with event data', async () => {
     const mockFetch = jest.fn().mockResolvedValue({ ok: true });
-    // @ts-ignore
+    // @ts-expect-error - mock fetch for analytics call
     global.fetch = mockFetch;
 
     await track('test-event', { foo: 'bar' });
@@ -23,7 +23,7 @@ describe('analytics track', () => {
 
   it('handles network errors gracefully', async () => {
     const mockFetch = jest.fn().mockRejectedValue(new Error('network failure'));
-    // @ts-ignore
+    // @ts-expect-error - mock fetch for error handling
     global.fetch = mockFetch;
 
     await expect(track('error-event')).resolves.toBeUndefined();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "test:accessibility": "node --test test/accessibility.test.js",
-    "test:lighthouse": "node --test test/lighthouse.test.js"
+    "test:lighthouse": "node --test test/lighthouse.test.js",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "@eslint/js": "^9.9.0",
@@ -104,6 +105,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@playwright/test": "^1.44.0"
   }
 }

--- a/tests/example.spec.js
+++ b/tests/example.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has title', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example Domain/);
+});


### PR DESCRIPTION
## Summary
- add `test:browser` script to run Playwright tests
- include basic example Playwright spec
- replace `@ts-ignore` comments with `@ts-expect-error` in analytics test to satisfy lint

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run test:browser` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b889b2fcd083289e2b055b9f1ebeff