### PR TITLE
Improve accessibility for password toggles on Get Started page

### DIFF
--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -177,6 +177,8 @@ export const GetStarted = () => {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                   >
                     {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
@@ -198,6 +200,8 @@ export const GetStarted = () => {
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                    aria-label="Toggle confirm password visibility"
+                    aria-pressed={showConfirmPassword}
                   >
                     {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>


### PR DESCRIPTION
## Summary
- add descriptive aria-labels and pressed state to password visibility toggle buttons in Get Started page

## Testing
- `npm run test:accessibility`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68b883203b2c8328b5aa5dbab776a035