### PR TITLE
Add management-fee handling for payments

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -164,7 +164,9 @@ Manages payment transactions:
 - id: UUID (Primary Key)
 - user_id: UUID (References profiles.id)
 - subscription_id: UUID (References user_subscriptions.id)
-- amount: INTEGER
+- amount: INTEGER -- amount after platform fee deduction
+- total_amount: INTEGER
+- platform_fee: INTEGER
 - currency: TEXT
 - status: TEXT (pending, completed, failed, refunded)
 - payment_method: TEXT (phone, card)

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -125,7 +125,12 @@ export interface Transaction {
   id: string;
   user_id: string;
   subscription_id?: string;
+  /** Amount after platform fee deduction */
   amount: number;
+  /** Total amount paid by user */
+  total_amount: number;
+  /** Platform/management fee collected */
+  platform_fee: number;
   currency: string;
   status: 'pending' | 'completed' | 'failed' | 'refunded';
   payment_method: 'phone' | 'card';

--- a/src/lib/services/subscription-service.ts
+++ b/src/lib/services/subscription-service.ts
@@ -414,14 +414,17 @@ export class TransactionService extends BaseService<Transaction> {
   async createTransaction(
     userId: string,
     subscriptionId: string,
-    amount: number,
+    totalAmount: number,
+    platformFee: number,
     paymentMethod: 'phone' | 'card',
     referenceNumber: string
   ): Promise<DatabaseResponse<Transaction>> {
     const transactionData = {
       user_id: userId,
       subscription_id: subscriptionId,
-      amount,
+      amount: totalAmount - platformFee,
+      total_amount: totalAmount,
+      platform_fee: platformFee,
       currency: 'ZMW', // Zambian Kwacha
       status: 'pending' as const,
       payment_method: paymentMethod,

--- a/supabase/functions/lenco-payment/index.ts
+++ b/supabase/functions/lenco-payment/index.ts
@@ -10,7 +10,11 @@ interface RequestBody {
 
 serve(async (req) => {
   try {
-    const { amount, paymentMethod, phoneNumber, provider, description } = (await req.json()) as RequestBody;
+    const { amount, paymentMethod, phoneNumber, provider, description } =
+      (await req.json()) as RequestBody;
+
+    // Calculate management/platform fee (2% of total amount)
+    const managementFee = amount * 0.02;
 
     const baseUrl = Deno.env.get('LENCO_API_BASE_URL');
     const apiKey = Deno.env.get('LENCO_API_KEY');
@@ -41,7 +45,11 @@ serve(async (req) => {
     }
 
     return new Response(
-      JSON.stringify({ success: true, transaction_id: result.transaction_id }),
+      JSON.stringify({
+        success: true,
+        transaction_id: result.transaction_id,
+        management_fee: managementFee,
+      }),
       { headers: { 'Content-Type': 'application/json' } },
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
- include management fee in Lenco payment function response
- track total amount and platform fee in transaction service
- document new transaction fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8c06e5ea48328a2680e5da724459a