### PR TITLE
Add tests for payment fee breakdown and subscription status

### DIFF
--- a/jest-tests/lenco-payment.test.tsx
+++ b/jest-tests/lenco-payment.test.tsx
@@ -1,0 +1,27 @@
+jest.mock('@/lib/supabase', () => ({
+  supabase: { functions: { invoke: jest.fn() } },
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import { render, screen } from '@testing-library/react';
+import { LencoPayment } from '@/components/LencoPayment';
+
+describe('LencoPayment fee breakdown', () => {
+  it.each([
+    { amount: 100, total: 'K100.00', fee: 'K2.00', provider: 'K98.00' },
+    { amount: 250.5, total: 'K250.50', fee: 'K5.01', provider: 'K245.49' },
+    { amount: 'K1,000', total: 'K1000.00', fee: 'K20.00', provider: 'K980.00' },
+  ])('renders correct breakdown for %p', ({ amount, total, fee, provider }) => {
+    render(<LencoPayment amount={amount} description="Test" />);
+    expect(screen.getByText(total)).toBeInTheDocument();
+    expect(screen.getByText(fee)).toBeInTheDocument();
+    expect(screen.getByText(provider)).toBeInTheDocument();
+  });
+});

--- a/jest-tests/subscription-service.integration.test.ts
+++ b/jest-tests/subscription-service.integration.test.ts
@@ -1,0 +1,46 @@
+const mockSingle = jest.fn();
+
+jest.mock('@/lib/supabase-enhanced', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: mockSingle,
+    })),
+  },
+  withErrorHandling: async (operation: any) => operation(),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import { SubscriptionService } from '@/lib/services/subscription-service';
+
+describe('SubscriptionService payment status integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates payment_status from pending to paid after activation', async () => {
+    const service = new SubscriptionService();
+
+    mockSingle
+      .mockResolvedValueOnce({
+        data: { id: 'sub1', payment_status: 'pending', status: 'pending' },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 'sub1', payment_status: 'paid', status: 'active' },
+        error: null,
+      });
+
+    const { data: pending } = await service.createSubscription('user1', 'plan1');
+    expect(pending?.payment_status).toBe('pending');
+
+    const { data: paid } = await service.activateSubscription('sub1');
+    expect(paid?.payment_status).toBe('paid');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for LencoPayment to verify fee calculations across multiple amounts
- add integration test ensuring subscription-service updates payment_status from pending to paid

## Testing
- `npm test`
- `npx jest --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0729ce8832881bb12e62b604b65