### PR TITLE
refactor: use subscription service

### DIFF
--- a/src/components/AccessGate.tsx
+++ b/src/components/AccessGate.tsx
@@ -5,6 +5,7 @@ import { Lock, Eye } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/utils/logger';
+import { SubscriptionService } from '@/lib/services/subscription-service';
 
 interface AccessGateProps {
   children: React.ReactNode;
@@ -16,6 +17,7 @@ export const AccessGate = ({ children, feature }: AccessGateProps) => {
   const [isTrialActive, setIsTrialActive] = useState(false);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const subscriptionService = new SubscriptionService();
 
   useEffect(() => {
     checkAccess();
@@ -30,14 +32,8 @@ export const AccessGate = ({ children, feature }: AccessGateProps) => {
       }
 
       // Check subscription status
-      const { data: subscription } = await supabase
-        .from('subscriptions')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('status', 'active')
-        .single();
-
-      if (subscription) {
+      const { data: hasSubscription } = await subscriptionService.hasActiveSubscription(user.id);
+      if (hasSubscription) {
         setHasAccess(true);
         setLoading(false);
         return;

--- a/src/components/SubscriptionCard.tsx
+++ b/src/components/SubscriptionCard.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
 import { LencoPayment } from '@/components/LencoPayment';
 import { logger } from '@/utils/logger';
+import { SubscriptionService } from '@/lib/services/subscription-service';
 
 interface SubscriptionPlan {
   id: string;
@@ -32,6 +33,7 @@ export const SubscriptionCard = ({ plan, userType, compact = false }: Subscripti
   const [showPayment, setShowPayment] = useState(false);
   const navigate = useNavigate();
   const { toast } = useToast();
+  const subscriptionService = new SubscriptionService();
 
   const handleSelectPlan = async () => {
     try {
@@ -54,14 +56,8 @@ export const SubscriptionCard = ({ plan, userType, compact = false }: Subscripti
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
-        await supabase.from('subscriptions').upsert({
-          user_id: user.id,
-          plan_id: plan.id,
-          plan_name: plan.name,
-          amount: plan.price,
-          status: 'active',
-          created_at: new Date().toISOString()
-        });
+        const { error } = await subscriptionService.createSubscription(user.id, plan.id);
+        if (error) throw error;
 
         toast({
           title: "Subscription Activated!",

--- a/src/components/TrialBanner.tsx
+++ b/src/components/TrialBanner.tsx
@@ -5,11 +5,13 @@ import { Clock, Crown } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/utils/logger';
+import { SubscriptionService } from '@/lib/services/subscription-service';
 
 export const TrialBanner = () => {
   const [daysLeft, setDaysLeft] = useState<number | null>(null);
   const [showBanner, setShowBanner] = useState(false);
   const navigate = useNavigate();
+  const subscriptionService = new SubscriptionService();
 
   useEffect(() => {
     checkTrialStatus();
@@ -21,14 +23,8 @@ export const TrialBanner = () => {
       if (!user) return;
 
       // Check if user has active subscription
-      const { data: subscription } = await supabase
-        .from('subscriptions')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('status', 'active')
-        .single();
-
-      if (subscription) return; // User has active subscription
+      const { data: hasSubscription } = await subscriptionService.hasActiveSubscription(user.id);
+      if (hasSubscription) return; // User has active subscription
 
       // Check trial status
       const { data: profile } = await supabase


### PR DESCRIPTION
## Summary
- use SubscriptionService in SubscriptionCard to create user subscriptions
- leverage SubscriptionService in AccessGate and TrialBanner instead of direct supabase queries

## Testing
- `npm test`
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_68b8bffeef14832889abee6ce1a416f0