### PR TITLE
feat: add funding hub and about links to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -50,6 +50,8 @@ const Footer = () => {
             <ul className="space-y-2">
               <li><Link to="/get-started" className="text-gray-300 hover:text-white transition-colors">Get Started</Link></li>
               <li><Link to="/resources" className="text-gray-300 hover:text-white transition-colors">Help Center</Link></li>
+              <li><Link to="/funding-hub" className="text-gray-300 hover:text-white transition-colors">Funding Hub</Link></li>
+              <li><Link to="/about" className="text-gray-300 hover:text-white transition-colors">About Us</Link></li>
               <li><Link to="/privacy-policy" className="text-gray-300 hover:text-white transition-colors">Privacy Policy</Link></li>
               <li><Link to="/terms-of-service" className="text-gray-300 hover:text-white transition-colors">Terms of Service</Link></li>
             </ul>


### PR DESCRIPTION
## Summary
- add Funding Hub and About Us links to footer support section
- match styling with existing footer links

## Testing
- `npm run lint`
- `npm test`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68b8bfc5e5048328b14b6a731b23ce7e