### PR TITLE
Add Funding Hub and About Us to header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,9 @@ const Header = () => {
     { name: 'Marketplace', href: '/marketplace' },
     { name: 'Freelancer Hub', href: '/freelancer-hub' },
     { name: 'Resources', href: '/resources' },
-    { name: 'Partnership Hub', href: '/partnership-hub' }
+    { name: 'Partnership Hub', href: '/partnership-hub' },
+    { name: 'Funding Hub', href: '/funding-hub' },
+    { name: 'About Us', href: '/about' }
   ];
 
   const handleSignOut = async () => {


### PR DESCRIPTION
## Summary
- extend header navigation with Funding Hub and About Us links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8bfc1fe5c8328a447ef21edca3b40