### PR TITLE
Add extended payment and bank fields to profiles

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -119,9 +119,16 @@ Manages payment transactions:
 - employee_count: INTEGER
 - annual_revenue: INTEGER
 - funding_stage: TEXT
-- payment_method: TEXT (phone, card)
+- payment_method: TEXT (phone, card, bank)
 - payment_phone: TEXT
+- mobile_money_provider: TEXT
 - card_details: JSONB
+- bank_account_name: TEXT
+- bank_account_number: TEXT
+- bank_name: TEXT
+- bank_branch: TEXT
+- bank_swift_code: TEXT
+- bank_currency: TEXT
 - qualifications: JSONB
 - experience_years: INTEGER
 - specialization: TEXT
@@ -167,7 +174,7 @@ Manages payment transactions:
 - amount: INTEGER
 - currency: TEXT
 - status: TEXT (pending, completed, failed, refunded)
-- payment_method: TEXT (phone, card)
+- payment_method: TEXT (phone, card, bank)
 - reference_number: TEXT (Unique)
 - created_at: TIMESTAMP
 - updated_at: TIMESTAMP

--- a/src/@types/database.ts
+++ b/src/@types/database.ts
@@ -65,12 +65,21 @@ export interface BusinessInfo {
 }
 
 export interface PaymentInfo {
-  payment_method: 'phone' | 'card';
+  payment_method: 'phone' | 'card' | 'bank';
   payment_phone?: string;
+  mobile_money_provider?: string;
   card_details?: {
     number: string;
     expiry: string;
+    holder_name?: string;
+    cvv?: string;
   };
+  bank_account_name?: string;
+  bank_account_number?: string;
+  bank_name?: string;
+  bank_branch?: string;
+  bank_swift_code?: string;
+  bank_currency?: string;
   use_same_phone?: boolean;
 }
 
@@ -128,7 +137,7 @@ export interface Transaction {
   amount: number;
   currency: string;
   status: 'pending' | 'completed' | 'failed' | 'refunded';
-  payment_method: 'phone' | 'card';
+  payment_method: 'phone' | 'card' | 'bank';
   reference_number: string;
   created_at: string;
   updated_at: string;

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -12,7 +12,7 @@ import { AddressInput } from '@/components/AddressInput';
 import { QualificationsInput } from '@/components/QualificationsInput';
 import { ImageUpload } from '@/components/ImageUpload';
 import { ArrowLeft } from 'lucide-react';
-import { sectors, countries } from '../data/countries';
+import { sectors, countries, currencies } from '../data/countries';
 
 interface ProfileFormProps {
   accountType: string;
@@ -30,6 +30,17 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
     gaps_identified: [],
     phone: '',
     payment_phone: '',
+    mobile_money_provider: '',
+    card_number: '',
+    card_expiry: '',
+    cardholder_name: '',
+    card_cvv: '',
+    bank_account_name: '',
+    bank_account_number: '',
+    bank_name: '',
+    bank_branch: '',
+    bank_swift_code: '',
+    bank_currency: '',
     profile_image_url: null,
     linkedin_url: '',
     ...initialData
@@ -270,18 +281,34 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
             <h3 className="text-lg font-semibold mb-4">Payment Information</h3>
             
             <div className="flex items-center space-x-2 mb-4">
-              <Checkbox 
+              <Checkbox
                 id="same-phone"
                 checked={formData.use_same_phone}
                 onCheckedChange={(checked) => handleInputChange('use_same_phone', checked)}
               />
               <Label htmlFor="same-phone">Use the same phone number for subscription payments</Label>
             </div>
+            {formData.use_same_phone && (
+              <div className="mb-4">
+                <Label>Mobile Money Provider</Label>
+                <Select
+                  value={formData.mobile_money_provider}
+                  onValueChange={(value) => handleInputChange('mobile_money_provider', value)}
+                >
+                  <SelectTrigger><SelectValue placeholder="Select provider" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mtn">MTN Mobile Money</SelectItem>
+                    <SelectItem value="airtel">Airtel Money</SelectItem>
+                    <SelectItem value="zamtel">Zamtel Kwacha</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             {!formData.use_same_phone && (
               <div className="space-y-4">
-                <RadioGroup 
-                  value={formData.payment_method} 
+                <RadioGroup
+                  value={formData.payment_method}
                   onValueChange={(value) => handleInputChange('payment_method', value)}
                 >
                   <div className="flex items-center space-x-2">
@@ -292,16 +319,134 @@ export const ProfileForm = ({ accountType, onSubmit, onPrevious, loading, initia
                     <RadioGroupItem value="card" id="card" />
                     <Label htmlFor="card">Credit/Debit Card</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="bank" id="bank" />
+                    <Label htmlFor="bank">Bank Transfer</Label>
+                  </div>
                 </RadioGroup>
 
                 {formData.payment_method === 'phone' && (
-                  <div>
-                    <Label>Payment Phone Number</Label>
-                    <Input 
-                      value={formData.payment_phone}
-                      onChange={(e) => handleInputChange('payment_phone', e.target.value)}
-                      placeholder="Country code will be auto-filled"
-                    />
+                  <>
+                    <div>
+                      <Label>Mobile Money Provider</Label>
+                      <Select
+                        value={formData.mobile_money_provider}
+                        onValueChange={(value) => handleInputChange('mobile_money_provider', value)}
+                      >
+                        <SelectTrigger><SelectValue placeholder="Select provider" /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="mtn">MTN Mobile Money</SelectItem>
+                          <SelectItem value="airtel">Airtel Money</SelectItem>
+                          <SelectItem value="zamtel">Zamtel Kwacha</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label>Payment Phone Number</Label>
+                      <Input
+                        value={formData.payment_phone}
+                        onChange={(e) => handleInputChange('payment_phone', e.target.value)}
+                        placeholder="Country code will be auto-filled"
+                      />
+                    </div>
+                  </>
+                )}
+
+                {formData.payment_method === 'card' && (
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label>Card Number</Label>
+                        <Input
+                          value={formData.card_number}
+                          onChange={(e) => handleInputChange('card_number', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label>Expiry Date</Label>
+                        <Input
+                          value={formData.card_expiry}
+                          onChange={(e) => handleInputChange('card_expiry', e.target.value)}
+                          placeholder="MM/YY"
+                        />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label>Cardholder Name</Label>
+                        <Input
+                          value={formData.cardholder_name}
+                          onChange={(e) => handleInputChange('cardholder_name', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label>CVV</Label>
+                        <Input
+                          value={formData.card_cvv}
+                          onChange={(e) => handleInputChange('card_cvv', e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {formData.payment_method === 'bank' && (
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label>Account Name</Label>
+                        <Input
+                          value={formData.bank_account_name}
+                          onChange={(e) => handleInputChange('bank_account_name', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label>Account Number</Label>
+                        <Input
+                          value={formData.bank_account_number}
+                          onChange={(e) => handleInputChange('bank_account_number', e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label>Bank Name</Label>
+                        <Input
+                          value={formData.bank_name}
+                          onChange={(e) => handleInputChange('bank_name', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label>Bank Branch</Label>
+                        <Input
+                          value={formData.bank_branch}
+                          onChange={(e) => handleInputChange('bank_branch', e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label>Swift Code</Label>
+                        <Input
+                          value={formData.bank_swift_code}
+                          onChange={(e) => handleInputChange('bank_swift_code', e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label>Currency</Label>
+                        <Select
+                          value={formData.bank_currency}
+                          onValueChange={(value) => handleInputChange('bank_currency', value)}
+                        >
+                          <SelectTrigger><SelectValue placeholder="Select currency" /></SelectTrigger>
+                          <SelectContent>
+                            {currencies.map(c => (
+                              <SelectItem key={c.code} value={c.code}>{c.name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/components/ProfileReview.tsx
+++ b/src/components/ProfileReview.tsx
@@ -249,21 +249,57 @@ export const ProfileReview = () => {
 
         {/* Payment Information */}
         <Card>
-          <CardHeader>
+        <CardHeader>
             <CardTitle>Payment Information</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="flex items-center gap-3">
               <Phone className="h-5 w-5 text-muted-foreground" />
               <span>
-                Payment Method: {profile.payment_method === 'phone' ? 'Mobile Money' : 'Card'}
+                Payment Method: {profile.payment_method === 'phone'
+                  ? 'Mobile Money'
+                  : profile.payment_method === 'card'
+                  ? 'Card'
+                  : 'Bank Transfer'}
               </span>
             </div>
-            {profile.payment_phone && (
+            {profile.payment_method === 'phone' && (
+              <>
+                {profile.mobile_money_provider && (
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-muted-foreground">Provider:</span>
+                    <span>{profile.mobile_money_provider}</span>
+                  </div>
+                )}
+                {profile.payment_phone && (
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-muted-foreground">Payment Phone:</span>
+                    <span>{profile.payment_phone}</span>
+                  </div>
+                )}
+              </>
+            )}
+            {profile.payment_method === 'card' && profile.card_details && (
               <div className="flex items-center gap-3 mt-2">
-                <span className="text-muted-foreground">Payment Phone:</span>
-                <span>{profile.payment_phone}</span>
+                <span className="text-muted-foreground">Card Holder:</span>
+                <span>{profile.card_details.holder_name}</span>
               </div>
+            )}
+            {profile.payment_method === 'bank' && (
+              <>
+                {profile.bank_account_name && (
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-muted-foreground">Account Name:</span>
+                    <span>{profile.bank_account_name}</span>
+                  </div>
+                )}
+                {profile.bank_name && (
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-muted-foreground">Bank:</span>
+                    <span>{profile.bank_name}</span>
+                  </div>
+                )}
+              </>
             )}
           </CardContent>
         </Card>

--- a/src/lib/services/subscription-service.ts
+++ b/src/lib/services/subscription-service.ts
@@ -415,7 +415,7 @@ export class TransactionService extends BaseService<Transaction> {
     userId: string,
     subscriptionId: string,
     amount: number,
-    paymentMethod: 'phone' | 'card',
+    paymentMethod: 'phone' | 'card' | 'bank',
     referenceNumber: string
   ): Promise<DatabaseResponse<Transaction>> {
     const transactionData = {

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -235,11 +235,18 @@ export class ProfileService extends BaseService<Profile> {
    * Update payment information
    */
   async updatePaymentInfo(
-    userId: string, 
+    userId: string,
     paymentData: {
-      payment_method: 'phone' | 'card';
+      payment_method: 'phone' | 'card' | 'bank';
       payment_phone?: string;
-      card_details?: { number: string; expiry: string };
+      mobile_money_provider?: string;
+      card_details?: { number: string; expiry: string; holder_name?: string; cvv?: string };
+      bank_account_name?: string;
+      bank_account_number?: string;
+      bank_name?: string;
+      bank_branch?: string;
+      bank_swift_code?: string;
+      bank_currency?: string;
       use_same_phone?: boolean;
     }
   ): Promise<DatabaseResponse<Profile>> {

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -107,11 +107,12 @@ export const ProfileSetup = () => {
     setLoading(true);
     
     try {
-      let paymentData = {};
+      let paymentData: Record<string, any> = {};
       if (profileData.use_same_phone) {
         paymentData = {
           payment_phone: profileData.phone,
-          payment_method: 'phone'
+          payment_method: 'phone',
+          mobile_money_provider: profileData.mobile_money_provider
         };
       } else {
         if (profileData.payment_method === 'card') {
@@ -119,23 +120,45 @@ export const ProfileSetup = () => {
             payment_method: 'card',
             card_details: {
               number: profileData.card_number,
-              expiry: profileData.card_expiry
+              expiry: profileData.card_expiry,
+              holder_name: profileData.cardholder_name,
+              cvv: profileData.card_cvv
             }
+          };
+        } else if (profileData.payment_method === 'bank') {
+          paymentData = {
+            payment_method: 'bank',
+            bank_account_name: profileData.bank_account_name,
+            bank_account_number: profileData.bank_account_number,
+            bank_name: profileData.bank_name,
+            bank_branch: profileData.bank_branch,
+            bank_swift_code: profileData.bank_swift_code,
+            bank_currency: profileData.bank_currency
           };
         } else {
           paymentData = {
             payment_method: 'phone',
-            payment_phone: profileData.payment_phone
+            payment_phone: profileData.payment_phone,
+            mobile_money_provider: profileData.mobile_money_provider
           };
         }
       }
+
+      const {
+        card_number,
+        card_expiry,
+        cardholder_name,
+        card_cvv,
+        mobile_money_provider,
+        ...profileDataToSave
+      } = profileData;
 
       const { error } = await supabase
         .from('profiles')
         .upsert({
           id: user.id,
           email: user.email,
-          ...profileData,
+          ...profileDataToSave,
           ...paymentData,
           profile_completed: true,
           updated_at: new Date().toISOString()

--- a/supabase/migrations/002_add_lenco_fields_to_profiles.sql
+++ b/supabase/migrations/002_add_lenco_fields_to_profiles.sql
@@ -1,0 +1,11 @@
+-- Add Lenco-specific payment fields to profiles table
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS mobile_money_provider TEXT,
+  ADD COLUMN IF NOT EXISTS bank_account_name TEXT,
+  ADD COLUMN IF NOT EXISTS bank_account_number TEXT,
+  ADD COLUMN IF NOT EXISTS bank_name TEXT,
+  ADD COLUMN IF NOT EXISTS bank_branch TEXT,
+  ADD COLUMN IF NOT EXISTS bank_swift_code TEXT,
+  ADD COLUMN IF NOT EXISTS bank_currency TEXT;
+


### PR DESCRIPTION
## Summary
- expand profile form to capture mobile money provider, cardholder, cvv, and bank transfer details
- persist new payment details in profile setup handler and database types
- document and migrate schema for new Lenco-specific profile fields

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b8be41d808832891dd6edaeee8c7f1