### PR TITLE
feat: add phone and Google auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import ServiceRequests from "./pages/ServiceRequests";
 import FundingHub from "@/pages/FundingHub";
 import About from "@/pages/About";
 import FeedbackWidget from "@/components/FeedbackWidget";
+import PhoneSignUp from "./pages/PhoneSignUp";
 
 const queryClient = new QueryClient();
 
@@ -35,6 +36,7 @@ export const AppRoutes = () => (
     <Route path="/resources" element={<Resources />} />
     <Route path="/signin" element={<SignIn />} />
     <Route path="/get-started" element={<GetStarted />} />
+    <Route path="/signup-phone" element={<PhoneSignUp />} />
     <Route path="/profile-setup" element={<ProfileSetup />} />
     <Route path="/profile-review" element={<ProfileReview />} />
     <Route path="/subscription-plans" element={<SubscriptionPlans />} />

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -110,6 +110,62 @@ export class UserService extends BaseService<User> {
   }
 
   /**
+   * Initiate phone number sign-in by sending an OTP
+   */
+  async signInWithPhone(phone: string): Promise<DatabaseResponse<void>> {
+    return withErrorHandling(
+      async () => {
+        const { error } = await supabase.auth.signInWithOtp({ phone });
+        return { data: undefined, error };
+      },
+      'UserService.signInWithPhone'
+    );
+  }
+
+  /**
+   * Verify phone OTP and return authenticated user
+   */
+  async verifyPhoneOtp(phone: string, token: string): Promise<DatabaseResponse<User>> {
+    return withErrorHandling(
+      async () => {
+        const { data, error } = await supabase.auth.verifyOtp({
+          phone,
+          token,
+          type: 'sms'
+        });
+
+        if (error || !data.user) {
+          return { data: null, error: error || new Error('Verification failed') };
+        }
+
+        return {
+          data: {
+            id: data.user.id,
+            email: data.user.email || '',
+            created_at: data.user.created_at,
+            updated_at: data.user.updated_at
+          },
+          error: null
+        };
+      },
+      'UserService.verifyPhoneOtp'
+    );
+  }
+
+  /**
+   * Sign in using Google OAuth
+   */
+  async signInWithGoogle(): Promise<DatabaseResponse<void>> {
+    return withErrorHandling(
+      async () => {
+        const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+        return { data: undefined, error };
+      },
+      'UserService.signInWithGoogle'
+    );
+  }
+
+  /**
    * Sign out current user
    */
   async signOut(): Promise<DatabaseResponse<void>> {

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -26,7 +26,7 @@ export const GetStarted = () => {
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { signUp } = useAppContext();
+  const { signUp, signInWithGoogle } = useAppContext();
 
   const handleInputChange = (field: string, value: string | boolean) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -83,7 +83,17 @@ export const GetStarted = () => {
               {error}
             </div>
           )}
-          
+
+          <Button type="button" variant="outline" className="w-full" onClick={signInWithGoogle}>
+            Sign up with Google
+          </Button>
+
+          <div className="text-center text-sm text-gray-600">
+            <Link to="/signup-phone" className="text-blue-600 hover:underline font-medium">
+              Sign up with phone
+            </Link>
+          </div>
+
           <form onSubmit={handleSignUp} className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">

--- a/src/pages/PhoneSignUp.tsx
+++ b/src/pages/PhoneSignUp.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { useAppContext } from '@/contexts/AppContext';
+import { useNavigate } from 'react-router-dom';
+
+const PhoneSignUp = () => {
+  const { signInWithPhone, verifyPhoneOtp } = useAppContext();
+  const [phone, setPhone] = useState('');
+  const [token, setToken] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await signInWithPhone(phone);
+      setOtpSent(true);
+    } catch {
+      // error toast handled in context
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await verifyPhoneOtp(phone, token);
+      navigate('/');
+    } catch {
+      // error toast handled in context
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 to-emerald-50">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle>Phone Sign In</CardTitle>
+          <CardDescription>Use your phone number to receive an OTP</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={otpSent ? handleVerify : handleSend} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="phone">Phone Number</Label>
+              <Input id="phone" value={phone} onChange={e => setPhone(e.target.value)} placeholder="+1234567890" required />
+            </div>
+            {otpSent && (
+              <div className="space-y-2">
+                <Label htmlFor="token">Verification Code</Label>
+                <Input id="token" value={token} onChange={e => setToken(e.target.value)} required />
+              </div>
+            )}
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Please wait...' : otpSent ? 'Verify Code' : 'Send Code'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PhoneSignUp;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -29,7 +29,7 @@ const SignIn = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const { signIn } = useAppContext();
+  const { signIn, signInWithGoogle } = useAppContext();
   const navigate = useNavigate();
 
   const {
@@ -153,6 +153,18 @@ const SignIn = () => {
                   Get Started
                 </Link>
               </p>
+            </div>
+
+            <div className="mt-6">
+              <Button variant="outline" className="w-full" onClick={signInWithGoogle}>
+                Sign in with Google
+              </Button>
+            </div>
+
+            <div className="mt-4 text-center">
+              <Link to="/signup-phone" className="text-orange-600 hover:text-orange-700 font-medium">
+                Sign in with phone
+              </Link>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- support phone-based authentication with OTP
- add Google OAuth sign-in
- expose phone auth UI and route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8c9f83f3083288b01e35afb9a6de9