### PR TITLE
fix: guard process usage in Supabase client

### DIFF
--- a/src/lib/supabase-enhanced.ts
+++ b/src/lib/supabase-enhanced.ts
@@ -8,7 +8,9 @@ import { logger } from '@/utils/logger';
 // Environment validation
 const validateEnvironment = (): { url: string; key: string } => {
   // Check if we're in test environment (Jest)
-  const isJestEnv = typeof jest !== 'undefined' || process?.env?.NODE_ENV === 'test';
+  const isJestEnv =
+    typeof jest !== 'undefined' ||
+    (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test');
   
   let url: string;
   let key: string;


### PR DESCRIPTION
## Summary
- guard process env reference when detecting test environment in Supabase client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b91a894bf48328a488537225c9fd06