### PR TITLE
Use Vite env mode for analytics logging

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -20,7 +20,7 @@ export async function track(event: string, data: Record<string, unknown> = {}): 
     }
   } catch (error) {
     // Swallow network errors to prevent impacting the app
-    if (process.env.NODE_ENV !== 'production') {
+    if (import.meta.env.MODE !== 'production') {
       console.error('Failed to send analytics event', { event, data, error });
     }
   }


### PR DESCRIPTION
## Summary
- replace `process.env.NODE_ENV` with `import.meta.env.MODE` in analytics utility

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b91aa037748328b620fa952ac1449b