### PR TITLE
feat: add error boundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component, ReactNode, ErrorInfo } from 'react';
+import { logger } from '@/utils/logger';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    logger.error('Unhandled error in component tree', { error, errorInfo }, 'ErrorBoundary');
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <div className="p-4 text-center">
+          <p className="text-red-600 font-medium">Something went wrong.</p>
+          <p>Please refresh the page and try again.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary';
+import { logger } from '@/utils/logger';
+
+jest.mock('@/utils/logger', () => ({
+  logger: { error: jest.fn() },
+}));
+
+const ProblemChild = () => {
+  throw new Error('Test error');
+};
+
+describe('ErrorBoundary', () => {
+  it('displays fallback message and logs error', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByText('Something went wrong.')
+    ).toBeInTheDocument();
+    expect(logger.error).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 // Remove dark mode class addition
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component that logs failures and renders a friendly fallback
- wrap root App in ErrorBoundary so initialization errors surface to users
- cover boundary behavior with unit test

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b93fbf35488328859a8a246cb843fd